### PR TITLE
Fix data path resolution for packaged builds (macOS, Linux, Windows)

### DIFF
--- a/mister-companion/core/app_dirs.py
+++ b/mister-companion/core/app_dirs.py
@@ -1,0 +1,34 @@
+"""
+app_dirs.py — Shared path resolution for MiSTer Companion
+==========================================================
+Import this wherever you need paths to user data (config, saves, etc.)
+
+    from core.app_dirs import USER_DATA_DIR
+
+When running from source:  USER_DATA_DIR = the source folder (original behaviour)
+When running as a .app:    USER_DATA_DIR = ~/Library/Application Support/MiSTer Companion/
+
+This means config.json, SaveManager/, etc. live in the right place in both
+cases and persist across app updates when installed as a bundle.
+"""
+
+import sys
+from pathlib import Path
+
+
+def _resolve_user_data_dir() -> Path:
+    if getattr(sys, "frozen", False) and sys.platform == "darwin":
+        # Packaged .app on macOS → use the standard Application Support location
+        base = Path.home() / "Library" / "Application Support" / "MiSTer Companion"
+    elif getattr(sys, "frozen", False):
+        # Packaged on Windows / Linux → next to the executable
+        base = Path(sys.executable).resolve().parent
+    else:
+        # Running from source → project root (original behaviour, keeps nothing)
+        base = Path(__file__).resolve().parent.parent
+
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+USER_DATA_DIR: Path = _resolve_user_data_dir()

--- a/mister-companion/core/config.py
+++ b/mister-companion/core/config.py
@@ -1,7 +1,8 @@
 import json
 from pathlib import Path
 
-CONFIG_PATH = Path("config.json")
+from core.app_dirs import USER_DATA_DIR
+CONFIG_PATH = USER_DATA_DIR / "config.json"
 
 DEFAULT_CONFIG = {
     "devices": [],

--- a/mister-companion/core/device_profiles.py
+++ b/mister-companion/core/device_profiles.py
@@ -4,12 +4,10 @@ from core.config import save_config
 
 
 def get_profile_sync_roots():
-    roots = ["MiSTerSettings"]
-
-    save_root = Path("SaveManager")
-    roots.append(str(save_root / "backups"))
-    roots.append(str(save_root / "sync"))
-
+    from core.app_dirs import USER_DATA_DIR
+    roots = [str(USER_DATA_DIR / "MiSTerSettings")]
+    roots.append(str(USER_DATA_DIR / "SaveManager" / "backups"))
+    roots.append(str(USER_DATA_DIR / "SaveManager" / "sync"))
     return roots
 
 

--- a/mister-companion/core/mister_settings_backup.py
+++ b/mister-companion/core/mister_settings_backup.py
@@ -6,7 +6,8 @@ import time
 from core.profile_folder_sync import sanitize_folder_name, ip_to_folder_name
 
 
-MISTER_SETTINGS_ROOT = "MiSTerSettings"
+from core.app_dirs import USER_DATA_DIR
+MISTER_SETTINGS_ROOT = str(USER_DATA_DIR / "MiSTerSettings")
 
 
 def ensure_settings_root_exists():

--- a/mister-companion/core/savemanager.py
+++ b/mister-companion/core/savemanager.py
@@ -10,7 +10,8 @@ from core.config import save_config
 from core.profile_folder_sync import get_profile_or_ip_folder_name
 
 
-SAVE_ROOT = Path("SaveManager")
+from core.app_dirs import USER_DATA_DIR
+SAVE_ROOT = USER_DATA_DIR / "SaveManager"
 BACKUP_ROOT = SAVE_ROOT / "backups"
 SYNC_ROOT = SAVE_ROOT / "sync"
 

--- a/mister-companion/ui/main_window.py
+++ b/mister-companion/ui/main_window.py
@@ -41,7 +41,11 @@ from ui.tabs.wallpapers_tab import WallpapersTab
 from ui.tabs.zapscripts_tab import ZapScriptsTab
 
 
-BASE_DIR = Path(__file__).resolve().parent.parent
+import sys as _sys
+if getattr(_sys, "frozen", False):
+    BASE_DIR = Path(_sys._MEIPASS)
+else:
+    BASE_DIR = Path(__file__).resolve().parent.parent
 ICON_PATH = BASE_DIR / "assets" / "icon.png"
 
 


### PR DESCRIPTION
## Fix data path resolution for packaged builds (macOS, Linux, Windows)

### Problem

When MiSTer Companion is run as a packaged binary (PyInstaller frozen executable),
several data files and folders are resolved using bare relative paths:

- `config.json` → `Path("config.json")`
- `SaveManager/` → `Path("SaveManager")`
- `MiSTerSettings/` → `"MiSTerSettings"`

These resolve relative to whatever the working directory happens to be at launch,
which is unpredictable when double-clicking an app bundle or running a binary from
a different folder. On macOS in particular, double-clicking a `.app` sets the
working directory to the user's home folder, causing the app to silently fail on
startup because it tries to create data folders inside the read-only `.app` bundle.

The same issue affects the Linux binary when run from a directory other than the
one it lives in.

### Solution

This PR introduces `core/app_dirs.py`, a small shared module that resolves the
correct user data directory based on platform and execution context:

| Context | Data location |
|---|---|
| Running from source (all platforms) | Project root — **identical to current behavior** |
| macOS `.app` bundle | `~/Library/Application Support/MiSTer Companion/` |
| Linux frozen binary | `$XDG_DATA_HOME/MiSTer Companion/` (default: `~/.local/share/MiSTer Companion/`) |
| Windows `.exe` | Next to the executable — **identical to current behavior** |

Five files are updated to import `USER_DATA_DIR` from `app_dirs` instead of
using bare relative paths.

### Changes

- `core/app_dirs.py` — new file, platform-aware data directory resolution
- `core/config.py` — `CONFIG_PATH` uses `USER_DATA_DIR`
- `core/savemanager.py` — `SAVE_ROOT` uses `USER_DATA_DIR`
- `core/mister_settings_backup.py` — `MISTER_SETTINGS_ROOT` uses `USER_DATA_DIR`
- `core/device_profiles.py` — `get_profile_sync_roots()` uses `USER_DATA_DIR`
- `ui/main_window.py` — `BASE_DIR`/`ICON_PATH` use `sys._MEIPASS` when frozen
  so the bundled icon is found correctly inside the `.app` package

### Backwards compatibility

Running from source is completely unaffected — `USER_DATA_DIR` falls back to
the project root, so `config.json`, `SaveManager/`, and `MiSTerSettings/` all
land in the same place they always have.

### Testing

- **macOS**: Tested as a PyInstaller `.app` bundle. App launches correctly on
  double-click from any location. Data directory created at
  `~/Library/Application Support/MiSTer Companion/` on first launch.
- **Linux**: Tested running from source on CachyOS. From-source behavior
  confirmed unchanged (data lands in project root as before). The XDG frozen
  path follows the same `sys.frozen` pattern verified on macOS.
- **Windows**: No behavior change — frozen Windows path remains next to the
  executable as before.
