### PR TITLE
feat(ci): add repository_dispatch to trigger Homebrew cask bump on re…

### DIFF
--- a/.github/workflows/dispatch-homebrew-bump.yml
+++ b/.github/workflows/dispatch-homebrew-bump.yml
@@ -1,0 +1,25 @@
+name: Dispatch Homebrew Cask Bump
+
+on:
+  release:
+    types: [published]   # Only fires when you manually create/publish a full Release
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send repository_dispatch to Homebrew tap
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_DISPATCH_PAT }}
+          # Choose one:
+          repository: Anime0t4ku/homebrew-mister-companion   # Recommended (if moving to org)
+          # repository: raishey/homebrew-mister-companion     # If keeping under your account
+          event-type: mister-companion-released
+          client-payload: |
+            {
+              "version": "${{ github.event.release.tag_name }}",
+              "release_url": "${{ github.event.release.html_url }}",
+              "is_prerelease": ${{ github.event.release.prerelease }}
+            }

--- a/.github/workflows/dispatch-homebrew-bump.yml
+++ b/.github/workflows/dispatch-homebrew-bump.yml
@@ -13,9 +13,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.HOMEBREW_DISPATCH_PAT }}
-          # Choose one:
-          repository: Anime0t4ku/homebrew-mister-companion   # Recommended (if moving to org)
-          # repository: raishey/homebrew-mister-companion     # If keeping under your account
+          repository: Anime0t4ku/homebrew-mister-companion
           event-type: mister-companion-released
           client-payload: |
             {


### PR DESCRIPTION
## What this PR does
Adds a new GitHub Actions workflow (.github/workflows/dispatch-homebrew-bump.yml) that automatically triggers a version bump in the [Homebrew tap](https://github.com/raishey/homebrew-mister-companion) (or the future Anime0t4ku/homebrew-mister-companion) whenever a new GitHub Release is published.

## Why
Currently, the Homebrew cask must be updated manually or via daily cron. This change makes the release process fully automated:

Publish a release → Homebrew cask gets a bump PR instantly
Keeps macOS users in sync with official releases
Eliminates maintainer toil

## How it works

Triggers only on release: published (not on every push or pre-release)
Uses peter-evans/repository-dispatch to send an event to the Homebrew tap
The tap’s own workflow then runs brew livecheck and opens a PR with the new version

This workflow runs alongside the existing build.yaml — no changes to current Windows/Linux builds or pre-release behavior.
Setup required (one-time)
After merging:

Add a repository secret in this repo: HOMEBREW_DISPATCH_PAT
Classic PAT with repo scope (or fine-grained with write access to the Homebrew tap repo)

(Recommended) Move the tap to Anime0t4ku/homebrew-mister-companion and update the repository: line accordingly.

Future improvements this enables

Later we can add a proper macOS build job to build.yaml and switch the cask from git-based to binary download.