### PR TITLE
Zapscraper Companion Output Lite routine as default

### DIFF
--- a/mister-companion/core/zapscraper.py
+++ b/mister-companion/core/zapscraper.py
@@ -20,7 +20,6 @@ from core.zapscraper_systems import (
     DISC_HELPER_EXTENSIONS,
     OUTPUT_FORMAT_RECALBOX,
     OUTPUT_FORMAT_ZAPAROO_COMPANION,
-    OUTPUT_FORMAT_ZAPAROO_COMPANION_LITE,
     REGION_TAGS,
     SUPPORTED_SYSTEMS,
     get_default_zaparoo_companion_media_names,
@@ -50,15 +49,8 @@ SCAN_CACHE_VERSION = 1
 
 _last_screenscraper_request_at = 0.0
 
-_ZAPAROO_FORMATS = {OUTPUT_FORMAT_ZAPAROO_COMPANION, OUTPUT_FORMAT_ZAPAROO_COMPANION_LITE}
-
-
 def _is_zaparoo_format(output_format: str) -> bool:
-    return output_format in _ZAPAROO_FORMATS
-
-
-def _is_zaparoo_lite(output_format: str) -> bool:
-    return output_format == OUTPUT_FORMAT_ZAPAROO_COMPANION_LITE
+    return output_format == OUTPUT_FORMAT_ZAPAROO_COMPANION
 
 
 class ScreenScraperQuotaError(RuntimeError):
@@ -478,7 +470,7 @@ def clear_scan_cache(source_mode: str, source_path: str | Path) -> bool:
 def normalize_output_format(output_format: str = "") -> str:
     value = str(output_format or "").strip()
 
-    if value in {OUTPUT_FORMAT_RECALBOX, OUTPUT_FORMAT_ZAPAROO_COMPANION, OUTPUT_FORMAT_ZAPAROO_COMPANION_LITE}:
+    if value in {OUTPUT_FORMAT_RECALBOX, OUTPUT_FORMAT_ZAPAROO_COMPANION}:
         return value
 
     return get_output_format_id(value)
@@ -2256,7 +2248,7 @@ def process_scrape_action(
         region_code = detect_region_from_filename(rom_filename, selected_region)
 
     zaparoo_slug_key: tuple[str, str] | None = None
-    if _is_zaparoo_lite(output_format) and zaparoo_slug_map is not None:
+    if _is_zaparoo_format(output_format) and zaparoo_slug_map is not None:
         slug = _slugify_rom_filename(rom_filename)
         zaparoo_slug_key = (action.get("system_folder", ""), slug)
         cached_id = zaparoo_slug_map.get(zaparoo_slug_key)
@@ -2287,7 +2279,7 @@ def process_scrape_action(
         rom_size=rom_size,
         system_id=system_id,
         zip_inner_path=rom.get("zip_inner_path", ""),
-        skip_hashes=_is_zaparoo_lite(output_format),
+        skip_hashes=_is_zaparoo_format(output_format),
         quota_callback=quota_callback,
     )
 
@@ -2300,7 +2292,7 @@ def process_scrape_action(
     if _is_zaparoo_format(output_format):
         zaparoo_result = apply_zaparoo_companion_scrape_result(
             system_path=action.get("system_path"),
-            relative_path=f"./{rom_filename}" if _is_zaparoo_lite(output_format) else action.get("relative_path"),
+            relative_path=f"./{rom_filename}",
             rom=rom,
             game=game,
             metadata=metadata,
@@ -2381,7 +2373,7 @@ def run_scrape_actions(
 
     slug_map: dict[tuple[str, str], str] = {}
 
-    if _is_zaparoo_lite(output_format):
+    if _is_zaparoo_format(output_format):
         seen_keys: set[tuple[str, str]] = set()
         deduped: list[dict[str, Any]] = []
         for action in actions:
@@ -2398,7 +2390,7 @@ def run_scrape_actions(
     if callable(log_callback):
         if _is_zaparoo_format(output_format):
             media_names = normalize_zaparoo_media_source_names(zaparoo_media_source_names)
-            label = "Zaparoo Companion Lite" if _is_zaparoo_lite(output_format) else "Zaparoo Companion Experimental"
+            label = "Zaparoo Companion"
             log_callback(
                 f"Output format: {label}. "
                 f"Media: {', '.join(media_names)}. Requests are single-threaded and rate-limited."
@@ -2430,7 +2422,7 @@ def run_scrape_actions(
                 skip_existing_metadata=skip_existing_metadata,
                 output_format=output_format,
                 zaparoo_media_source_names=zaparoo_media_source_names,
-                zaparoo_slug_map=slug_map if _is_zaparoo_lite(output_format) else None,
+                zaparoo_slug_map=slug_map if _is_zaparoo_format(output_format) else None,
                 quota_callback=quota_callback,
             )
 

--- a/mister-companion/core/zapscraper.py
+++ b/mister-companion/core/zapscraper.py
@@ -1,5 +1,6 @@
 import binascii
 import hashlib
+import html
 import json
 import re
 import sys
@@ -1052,6 +1053,18 @@ def safe_media_filename(name: str) -> str:
     return name
 
 
+def safe_game_name_for_filename(name: str) -> str:
+    name = str(name or "").strip()
+    name = html.unescape(name)
+    name = re.sub(r"[\t\n\r]", "", name)
+    name = re.sub(r"[\x00-\x1f\x7f]", "", name)
+    name = name.replace(":", "-")
+    name = re.sub(r'[<>"/\\|?*]', "", name)
+    name = re.sub(r"\s+", " ", name)
+    name = name.strip(" .")
+    return name or "unknown"
+
+
 def update_game_image(game: ET.Element, image_relative_path: str):
     set_child_text(game, "image", image_relative_path)
 
@@ -1920,7 +1933,7 @@ def select_media_url_by_media_type(
 
 def build_zaparoo_companion_media_path(
     system_path: str | Path,
-    screenscraper_id: str | int,
+    game_name: str,
     media_source_name: str,
     extension: str = ".png",
 ) -> tuple[Path, str]:
@@ -1930,11 +1943,32 @@ def build_zaparoo_companion_media_path(
     if not media_folder:
         media_folder = "media/zaparoo"
 
-    safe_id = safe_media_filename(str(screenscraper_id or "unknown"))
+    safe_name = safe_game_name_for_filename(game_name)
     media_dir = system_path / media_folder
-    media_path = media_dir / f"{safe_id}{extension}"
+    media_path = media_dir / f"{safe_name}{extension}"
 
     return media_path, f"./{media_folder}/{media_path.name}"
+
+
+_MEDIA_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp")
+
+
+def find_existing_zaparoo_media(
+    system_path: str | Path,
+    game_name: str,
+    media_source_name: str,
+) -> tuple[Path, str] | None:
+    system_path = Path(system_path)
+    media_folder = get_zaparoo_companion_media_folder(media_source_name) or "media/zaparoo"
+    safe_name = safe_game_name_for_filename(game_name)
+    media_dir = system_path / media_folder
+
+    for ext in _MEDIA_EXTENSIONS:
+        candidate = media_dir / f"{safe_name}{ext}"
+        if candidate.exists():
+            return candidate, f"./{media_folder}/{candidate.name}"
+
+    return None
 
 
 def find_zaparoo_parent_entry(root: ET.Element, screenscraper_id: str | int) -> ET.Element | None:
@@ -1987,6 +2021,8 @@ def get_or_create_zaparoo_child_entry(
         "publisher",
         "genre",
         "players",
+        "region",
+        "lang",
         "image",
         "thumbnail",
         "marquee",
@@ -2033,7 +2069,7 @@ def download_zaparoo_companion_media_assets(
     system_path: str | Path,
     parent: ET.Element,
     game: dict[str, Any],
-    screenscraper_id: str | int,
+    game_name: str,
     region_code: str,
     media_source_names=None,
 ) -> dict[str, str]:
@@ -2045,6 +2081,13 @@ def download_zaparoo_companion_media_assets(
         xml_node = get_zaparoo_companion_media_node(media_source_name)
 
         if not media_type or not xml_node:
+            continue
+
+        existing = find_existing_zaparoo_media(system_path, game_name, media_source_name)
+        if existing:
+            media_path, media_relative_path = existing
+            set_child_text(parent, xml_node, media_relative_path)
+            downloaded[xml_node] = media_relative_path
             continue
 
         media_url = select_media_url_by_media_type(
@@ -2059,7 +2102,7 @@ def download_zaparoo_companion_media_assets(
         extension = guess_image_extension(media_url)
         media_path, media_relative_path = build_zaparoo_companion_media_path(
             system_path,
-            screenscraper_id,
+            game_name,
             media_source_name,
             extension=extension,
         )
@@ -2101,22 +2144,19 @@ def apply_zaparoo_companion_scrape_result(
         system_path=system_path,
         parent=parent,
         game=game,
-        screenscraper_id=screenscraper_id,
+        game_name=str(metadata.get("name") or ""),
         region_code=region,
         media_source_names=media_source_names,
     )
 
     child = get_or_create_zaparoo_child_entry(tree, relative_path, screenscraper_id)
 
-    if region and region != "auto":
-        set_child_text(child, "region", region)
-
-        if region == "jp":
-            set_child_text(child, "lang", "jp")
-        elif region == "us":
-            set_child_text(child, "lang", "en")
-        elif region == "eu":
-            set_child_text(child, "lang", "en")
+    rom_filename = rom.get("filename") or ""
+    api_region, api_lang = _match_rom_region_lang(game, rom_filename)
+    if api_region:
+        set_child_text(child, "region", api_region)
+    if api_lang:
+        set_child_text(child, "lang", api_lang)
 
     update_cache_entry(
         cache,
@@ -2136,6 +2176,38 @@ def apply_zaparoo_companion_scrape_result(
         "media_paths": media_paths,
         "region": region,
     }
+
+
+def _match_rom_region_lang(game: dict[str, Any], rom_filename: str) -> tuple[str, str]:
+    roms = game.get("roms")
+    if not isinstance(roms, list) or not rom_filename:
+        return "", ""
+
+    stem = Path(rom_filename).stem.lower()
+
+    for entry in roms:
+        if not isinstance(entry, dict):
+            continue
+
+        api_filename = str(entry.get("romfilename") or "").strip()
+        if not api_filename:
+            continue
+
+        if Path(api_filename).stem.lower() != stem:
+            continue
+
+        regions = entry.get("regions") or {}
+        langues = entry.get("langues") or {}
+
+        region_names = regions.get("regions_shortname") if isinstance(regions, dict) else None
+        lang_names = langues.get("langues_shortname") if isinstance(langues, dict) else None
+
+        region = str(region_names[0]).strip() if isinstance(region_names, list) and region_names else ""
+        lang = str(lang_names[0]).strip() if isinstance(lang_names, list) and lang_names else ""
+
+        return region, lang
+
+    return "", ""
 
 
 def _slugify_rom_filename(filename: str) -> str:

--- a/mister-companion/core/zapscraper_systems.py
+++ b/mister-companion/core/zapscraper_systems.py
@@ -32,13 +32,11 @@ IMAGE_SOURCES = {
 
 OUTPUT_FORMAT_RECALBOX = "recalbox"
 OUTPUT_FORMAT_ZAPAROO_COMPANION = "zaparoo_companion"
-OUTPUT_FORMAT_ZAPAROO_COMPANION_LITE = "zaparoo_companion_lite"
 
 
 OUTPUT_FORMATS = {
     "Recalbox Compatible": OUTPUT_FORMAT_RECALBOX,
-    "Zaparoo Companion Experimental": OUTPUT_FORMAT_ZAPAROO_COMPANION,
-    "Zaparoo Companion Lite": OUTPUT_FORMAT_ZAPAROO_COMPANION_LITE,
+    "Zaparoo Companion": OUTPUT_FORMAT_ZAPAROO_COMPANION,
 }
 
 


### PR DESCRIPTION
---

## Zaparoo Companion: game-name media files, API region/lang, and lite format merge

### Media files named by game title

Zaparoo Companion media assets are now named after the game's scraped title instead of its ScreenScraper numeric ID. A new `safe_game_name_for_filename` filter produces the filename:

- HTML entities decoded (`&amp;` → `&`, etc.)
- Tab/newline/carriage-return stripped
- Control characters (0x00–0x1F, 0x7F) stripped
- Colons converted to dashes (`Castlevania: SOTN` → `Castlevania- SOTN`)
- Remaining path-unsafe characters (`<>"/\|?*`) replaced with underscores
- Commas left as-is
- Whitespace collapsed; leading/trailing spaces and dots trimmed

Files are now human-readable on disk and deterministic across re-scrapes of the same title.

### Media existence check before download

Before resolving a URL from the ScreenScraper response, the scraper checks whether a file matching the safe game name already exists (scanning `.png`, `.jpg`, `.jpeg`, `.webp`). If found, the existing file is reused and no network request is made. This prevents redundant downloads even if the extension differs from a previous run.

### Region and language from ScreenScraper ROM data

Region and language tags on gamelist child entries are now sourced directly from the ScreenScraper API by matching the ROM filename against the game's ROM list (`regions_shortname`, `langues_shortname`). Previously these were inferred heuristically from the selected region setting. The `region` and `lang` nodes are also cleared on child entry refresh to prevent stale values persisting.

### Zaparoo Companion Lite merged into Zaparoo Companion

The separate "Zaparoo Companion Lite" output format has been absorbed into "Zaparoo Companion." All lite behaviours are now the standard path:

- Hash calculation skipped (filename-only matching against ScreenScraper)
- ROM filename used as the gamelist relative path
- Deduplication by filename slug before scraping begins
- Slug map caching to skip API calls for repeat titles across multi-region ROM sets

`OUTPUT_FORMAT_ZAPAROO_COMPANION_LITE`, `_is_zaparoo_lite`, and the `"Zaparoo Companion Lite"` dropdown entry are removed.