### PR TITLE
Add macOS (Apple Silicon) support to release setup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -201,6 +201,95 @@ jobs:
           path: mister-companion/dist/MiSTer-Companion
 
 
+
+  # ============================================================
+  # macOS Build
+  # ============================================================
+  build-macos:
+    name: Build macOS App
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Dependencies
+        working-directory: mister-companion
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install -r requirements.txt
+
+      - name: Generate ScreenScraper private credentials
+        working-directory: mister-companion
+        shell: python
+        env:
+          SCREENSCRAPER: ${{ secrets.SCREENSCRAPER }}
+        run: |
+          import json
+          import os
+          from pathlib import Path
+
+          secret = os.environ.get("SCREENSCRAPER", "").strip()
+          target = Path("core/screenscraper_private.py")
+
+          dev_id = ""
+          dev_password = ""
+          softname = "mister-companion"
+
+          if secret:
+              data = json.loads(secret)
+              dev_id = data.get("dev_id", "")
+              dev_password = data.get("dev_password", "")
+              softname = data.get("softname", "mister-companion")
+
+              if not dev_id or not dev_password or not softname:
+                  raise SystemExit("SCREENSCRAPER secret is missing dev_id, dev_password, or softname")
+          else:
+              print("SCREENSCRAPER secret not available, building without ScreenScraper developer credentials.")
+
+          target.write_text(
+              f'''SS_DEV_ID = {dev_id!r}
+          SS_DEV_PASSWORD = {dev_password!r}
+          SS_SOFTNAME = {softname!r}
+
+
+          def has_dev_credentials():
+              return bool(SS_DEV_ID and SS_DEV_PASSWORD and SS_SOFTNAME)
+
+
+          def get_dev_credentials():
+              if not has_dev_credentials():
+                  return None
+
+              return {{
+                  "devid": SS_DEV_ID,
+                  "devpassword": SS_DEV_PASSWORD,
+                  "softname": SS_SOFTNAME,
+              }}
+          ''',
+              encoding="utf-8",
+          )
+
+      - name: Build Executable
+        working-directory: mister-companion
+        run: pyinstaller --clean --windowed --noconfirm --add-data "assets:assets" --name MiSTer-Companion main.py
+
+      - name: Package macOS App
+        working-directory: mister-companion/dist
+        run: zip -r MiSTer-Companion-macOS.zip MiSTer-Companion.app
+
+      - name: Upload macOS Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: MiSTer-Companion-macOS
+          path: mister-companion/dist/MiSTer-Companion-macOS.zip
+
   # ============================================================
   # Pre-release Creation
   # ============================================================
@@ -210,6 +299,7 @@ jobs:
     needs:
       - build-windows
       - build-linux
+      - build-macos
     if: github.ref == 'refs/heads/main'
 
     steps:
@@ -234,6 +324,11 @@ jobs:
           cd dist
           tar -czvf ../MiSTer-Companion-Linux-x86_64.tar.gz MiSTer-Companion
 
+
+      - name: Move macOS Build
+        run: |
+          mv dist/MiSTer-Companion-macOS.zip MiSTer-Companion-macOS.zip
+
       - name: Update Git Tag
         run: |
           git tag -f Pre-release
@@ -249,3 +344,4 @@ jobs:
           artifacts: |
             MiSTer-Companion-Windows-x86_64.zip
             MiSTer-Companion-Linux-x86_64.tar.gz
+            MiSTer-Companion-macOS.zip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -282,13 +282,13 @@ jobs:
 
       - name: Package macOS App
         working-directory: mister-companion/dist
-        run: zip -r MiSTer-Companion-macOS.zip MiSTer-Companion.app
+        run: zip -r MiSTer-Companion-macOS-arm64.zip MiSTer-Companion.app
 
       - name: Upload macOS Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MiSTer-Companion-macOS
-          path: mister-companion/dist/MiSTer-Companion-macOS.zip
+          name: MiSTer-Companion-macOS-arm64
+          path: mister-companion/dist/MiSTer-Companion-macOS-arm64.zip
 
   # ============================================================
   # Pre-release Creation
@@ -327,7 +327,7 @@ jobs:
 
       - name: Move macOS Build
         run: |
-          mv dist/MiSTer-Companion-macOS.zip MiSTer-Companion-macOS.zip
+          mv dist/MiSTer-Companion-macOS-arm64.zip MiSTer-Companion-macOS-arm64.zip
 
       - name: Update Git Tag
         run: |
@@ -344,4 +344,4 @@ jobs:
           artifacts: |
             MiSTer-Companion-Windows-x86_64.zip
             MiSTer-Companion-Linux-x86_64.tar.gz
-            MiSTer-Companion-macOS.zip
+            MiSTer-Companion-macOS-arm64.zip

--- a/readme.md
+++ b/readme.md
@@ -140,7 +140,7 @@ MiSTer Companion uses a tabbed interface to organize functionality.
 |------|----------|--------|------|
 | MiSTer Companion | Windows x86-64 | [![Build Status](https://github.com/Anime0t4ku/mister-companion/actions/workflows/build.yaml/badge.svg)](https://github.com/Anime0t4ku/mister-companion/actions/workflows/build.yaml) | [Download](https://github.com/Anime0t4ku/mister-companion/releases/download/Pre-release/MiSTer-Companion-Windows-x86_64.zip) |
 | MiSTer Companion | Linux x86-64 | [![Build Status](https://github.com/Anime0t4ku/mister-companion/actions/workflows/build.yaml/badge.svg)](https://github.com/Anime0t4ku/mister-companion/actions/workflows/build.yaml) | [Download](https://github.com/Anime0t4ku/mister-companion/releases/download/Pre-release/MiSTer-Companion-Linux-x86_64.tar.gz) |
-| MiSTer Companion | macOS | [![Build Status](https://github.com/Anime0t4ku/mister-companion/actions/workflows/build.yaml/badge.svg)](https://github.com/Anime0t4ku/mister-companion/actions/workflows/build.yaml) | [Download](https://github.com/Anime0t4ku/mister-companion/releases/download/Pre-release/MiSTer-Companion-macOS.zip) |
+| MiSTer Companion | macOS (Apple Silicon) | [![Build Status](https://github.com/Anime0t4ku/mister-companion/actions/workflows/build.yaml/badge.svg)](https://github.com/Anime0t4ku/mister-companion/actions/workflows/build.yaml) | [Download](https://github.com/Anime0t4ku/mister-companion/releases/download/Pre-release/MiSTer-Companion-macOS-arm64.zip) |
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -140,8 +140,7 @@ MiSTer Companion uses a tabbed interface to organize functionality.
 |------|----------|--------|------|
 | MiSTer Companion | Windows x86-64 | [![Build Status](https://github.com/Anime0t4ku/mister-companion/actions/workflows/build.yaml/badge.svg)](https://github.com/Anime0t4ku/mister-companion/actions/workflows/build.yaml) | [Download](https://github.com/Anime0t4ku/mister-companion/releases/download/Pre-release/MiSTer-Companion-Windows-x86_64.zip) |
 | MiSTer Companion | Linux x86-64 | [![Build Status](https://github.com/Anime0t4ku/mister-companion/actions/workflows/build.yaml/badge.svg)](https://github.com/Anime0t4ku/mister-companion/actions/workflows/build.yaml) | [Download](https://github.com/Anime0t4ku/mister-companion/releases/download/Pre-release/MiSTer-Companion-Linux-x86_64.tar.gz) |
-
-macOS users will have to wait just a bit longer for the official release.
+| MiSTer Companion | macOS | [![Build Status](https://github.com/Anime0t4ku/mister-companion/actions/workflows/build.yaml/badge.svg)](https://github.com/Anime0t4ku/mister-companion/actions/workflows/build.yaml) | [Download](https://github.com/Anime0t4ku/mister-companion/releases/download/Pre-release/MiSTer-Companion-macOS.zip) |
 
 ---
 


### PR DESCRIPTION
This PR adds a macOS (Apple Silicon / ARM64) build job to the GitHub Actions workflow, using pyinstaller to package the app into a zip file for release. It also updates the readme to include a link to the macOS build. Since there was an issue opened regarding a community port where you expressed interest, this enables automatic building of the official release on macOS. Happy to make changes if needed!