### PR TITLE
Fix macOS packaged cert env for offline updater

### DIFF
--- a/mister-companion/core/runtime_env.py
+++ b/mister-companion/core/runtime_env.py
@@ -1,0 +1,21 @@
+import os
+from pathlib import Path
+
+from core.app_paths import is_macos_packaged_app
+
+
+def configure_packaged_certificates():
+    if not is_macos_packaged_app():
+        return
+
+    try:
+        import certifi
+    except Exception:
+        return
+
+    cert_path = certifi.where()
+    if not cert_path or not Path(cert_path).is_file():
+        return
+
+    os.environ.setdefault("SSL_CERT_FILE", cert_path)
+    os.environ.setdefault("REQUESTS_CA_BUNDLE", cert_path)

--- a/mister-companion/main.py
+++ b/mister-companion/main.py
@@ -2,6 +2,7 @@ import sys
 from PyQt6.QtWidgets import QApplication
 
 from core.config import load_config
+from core.runtime_env import configure_packaged_certificates
 from core.theme import apply_theme
 from ui.custom_dialog import install_custom_dialogs
 from ui.custom_message_dialog import install_custom_message_boxes
@@ -9,6 +10,8 @@ from ui.main_window import MainWindow
 
 
 def main():
+    configure_packaged_certificates()
+
     app = QApplication(sys.argv)
 
     config = load_config()

--- a/mister-companion/requirements.txt
+++ b/mister-companion/requirements.txt
@@ -1,6 +1,7 @@
 PyQt6
 paramiko
 requests
+certifi
 websocket-client
 psutil
 pyserial

--- a/mister-companion/tests/test_runtime_env.py
+++ b/mister-companion/tests/test_runtime_env.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+import certifi
+
+from core.runtime_env import configure_packaged_certificates
+
+
+class ConfigurePackagedCertificatesTest(unittest.TestCase):
+    def test_sets_certifi_env_for_packaged_macos_app(self):
+        with (
+            patch.object(sys, "platform", "darwin"),
+            patch.object(sys, "frozen", True, create=True),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            configure_packaged_certificates()
+
+            self.assertEqual(os.environ["SSL_CERT_FILE"], certifi.where())
+            self.assertEqual(os.environ["REQUESTS_CA_BUNDLE"], certifi.where())
+
+    def test_does_not_overwrite_existing_cert_env(self):
+        env = {
+            "SSL_CERT_FILE": "/custom/ssl.pem",
+            "REQUESTS_CA_BUNDLE": "/custom/requests.pem",
+        }
+        with (
+            patch.object(sys, "platform", "darwin"),
+            patch.object(sys, "frozen", True, create=True),
+            patch.dict(os.environ, env, clear=True),
+        ):
+            configure_packaged_certificates()
+
+            self.assertEqual(os.environ["SSL_CERT_FILE"], "/custom/ssl.pem")
+            self.assertEqual(os.environ["REQUESTS_CA_BUNDLE"], "/custom/requests.pem")
+
+    def test_does_nothing_outside_packaged_macos_app(self):
+        with (
+            patch.object(sys, "platform", "linux"),
+            patch.object(sys, "frozen", True, create=True),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            configure_packaged_certificates()
+
+            self.assertNotIn("SSL_CERT_FILE", os.environ)
+            self.assertNotIn("REQUESTS_CA_BUNDLE", os.environ)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #82

## Summary
- set bundled certifi CA paths for packaged macOS app launches
- preserve existing user-provided certificate env vars
- add a small unittest for the runtime env behavior

## Test
- `python3 -m unittest discover -s tests`
- `python3 -m compileall -q .`
