### PR TITLE
feat(romm): RomM integration tab (see #92)

### DIFF
--- a/mister-companion/core/config.py
+++ b/mister-companion/core/config.py
@@ -24,7 +24,38 @@ DEFAULT_CONFIG = {
     "menu_style": "side_menu",
     "remember_offline_sd_root": False,
     "offline_sd_root": "",
+    "romm_config": {
+        "url": "",
+        "token": "",
+        "token_id": None,
+        "token_name": "",
+        "user_display": "",
+        "sync_platforms": [],
+        "sync_collections": [],
+        "readonly_platforms": [],
+        "readonly_collections": [],
+        "sync_last_run": "",
+        "sync_last_stats": {},
+        "sync_manifest": {},
+        "auto_sync": False,
+        "sync_saves": False,
+        "core_overrides": {},
+        "mister_root": "/media/fat",
+        "hide_unsupported": True,
+        "hide_empty": True,
+    },
 }
+
+
+def _normalize_mister_root(value) -> str:
+    """MiSTer's game root path. Must be absolute, no trailing slash.
+
+    Common values: /media/fat (SD), /media/usb0..5 (USB), /media/network (CIFS).
+    """
+    raw = str(value or "/media/fat").strip()
+    if not raw.startswith("/"):
+        raw = "/media/fat"
+    return raw.rstrip("/") or "/media/fat"
 
 
 def normalize_theme_mode(value):
@@ -71,6 +102,47 @@ def normalize_config(data):
         merged["offline_sd_root"] = str(merged.get("offline_sd_root", "") or "").strip()
     else:
         merged["offline_sd_root"] = ""
+
+    romm = merged.get("romm_config") or {}
+    if not isinstance(romm, dict):
+        romm = {}
+    token_id = romm.get("token_id")
+    if not isinstance(token_id, int):
+        token_id = None
+
+    def _int_list(v):
+        if not isinstance(v, list):
+            return []
+        out = []
+        for x in v:
+            if isinstance(x, int):
+                out.append(x)
+        return out
+
+    merged["romm_config"] = {
+        "url": str(romm.get("url", "") or "").strip(),
+        "token": str(romm.get("token", "") or ""),
+        "token_id": token_id,
+        "token_name": str(romm.get("token_name", "") or ""),
+        "user_display": str(romm.get("user_display", "") or ""),
+        "sync_platforms": _int_list(romm.get("sync_platforms")),
+        "sync_collections": _int_list(romm.get("sync_collections")),
+        "readonly_platforms": _int_list(romm.get("readonly_platforms")),
+        "readonly_collections": _int_list(romm.get("readonly_collections")),
+        "sync_last_run": str(romm.get("sync_last_run", "") or ""),
+        "sync_last_stats": romm.get("sync_last_stats") if isinstance(romm.get("sync_last_stats"), dict) else {},
+        "sync_manifest": romm.get("sync_manifest") if isinstance(romm.get("sync_manifest"), dict) else {},
+        "auto_sync": bool(romm.get("auto_sync", False)),
+        "sync_saves": bool(romm.get("sync_saves", False)),
+        "core_overrides": {
+            str(k).lower().strip(): str(v or "").strip()
+            for k, v in (romm.get("core_overrides") or {}).items()
+            if k
+        } if isinstance(romm.get("core_overrides"), dict) else {},
+        "mister_root": _normalize_mister_root(romm.get("mister_root")),
+        "hide_unsupported": bool(romm.get("hide_unsupported", True)),
+        "hide_empty": bool(romm.get("hide_empty", True)),
+    }
 
     return merged
 

--- a/mister-companion/core/mister_cores.py
+++ b/mister-companion/core/mister_cores.py
@@ -1,0 +1,222 @@
+"""RomM platform slug → MiSTer core folder mapping.
+
+MiSTer stores game ROMs under ``/media/fat/games/<Core>/`` (per the MiSTer wiki:
+https://mister-devel.github.io/MkDocs_MiSTer/setup/games/). Core folder names
+don't match RomM's slugs, so we bundle a translation table.
+
+Returns ``None`` for slugs with no known MiSTer core (Switch, PS3, GameCube,
+Wii U, 3DS, etc.). The sync engine skips these with a warning; the browse UI
+hides them behind a "Show unsupported" toggle.
+"""
+from __future__ import annotations
+
+# The core folder name under /media/fat/games/. Multiple RomM slugs can map to
+# the same MiSTer folder (e.g. TG-16 and PC Engine → TGFX16).
+# Folder names cross-checked against a real MiSTer install (2026-07). Case is
+# significant — MiSTer's paths are case-sensitive on the SD card's ext4.
+_SLUG_TO_CORE: dict[str, str] = {
+    # Nintendo
+    "nes":              "NES",
+    "famicom":          "NES",
+    "fds":              "NES",             # Famicom Disk System uses the NES core
+    "snes":             "SNES",
+    "sfc":              "SNES",
+    "super-famicom":    "SNES",
+    "n64":              "N64",
+    "gb":               "GAMEBOY",         # MiSTer folder is uppercase
+    "gbc":              "GBC",             # dedicated folder on MiSTer
+    "gba":              "GBA",
+    "sgb":              "SGB",             # Super Game Boy
+    "vb":               "VirtualBoy",
+    "virtualboy":       "VirtualBoy",
+    # Sega — MiSTer's core is named "MegaDrive" (international name), even for
+    # RomM slugs that use "genesis" (US colloquial).
+    "genesis-slash-megadrive": "MegaDrive",
+    "genesis":          "MegaDrive",
+    "megadrive":        "MegaDrive",
+    "sms":              "SMS",
+    "gg":               "GameGear",        # dedicated folder on MiSTer
+    "gamegear":         "GameGear",
+    "sg1000":           "SG-1000",
+    "segacd":           "MegaCD",
+    "sega-cd":          "MegaCD",
+    "sega32x":          "S32X",
+    "32x":              "S32X",
+    "saturn":           "Saturn",
+    # NEC
+    "turbografx16-slash-pcengine": "TGFX16",
+    "turbografx-16":    "TGFX16",
+    "pcengine":         "TGFX16",
+    "pce":              "TGFX16",
+    "pcecd":            "TGFX16-CD",
+    "turbografx-16-cd": "TGFX16-CD",
+    # SNK
+    "neogeoaes":        "NEOGEO",
+    "neogeomvs":        "NEOGEO",
+    "neogeocd":         "NeoGeo-CD",
+    "neogeopocket":     "NeoGeoPocket",    # dedicated folder on MiSTer
+    "ngp":              "NeoGeoPocket",
+    "ngpc":             "NeoGeoPocket",
+    # Sony
+    "psx":              "PSX",
+    "ps":               "PSX",
+    "ps1":              "PSX",
+    "playstation":      "PSX",
+    # Atari
+    "atari2600":        "Atari2600",       # dedicated standalone core folder
+    "atari5200":        "ATARI5200",
+    "atari7800":        "ATARI7800",
+    "atari-lynx":       "AtariLynx",
+    "lynx":             "AtariLynx",
+    "atari8bit":        "ATARI800",
+    "atari-8-bit":      "ATARI800",
+    "jaguar":           "Jaguar",
+    # Bandai
+    "wonderswan":       "WonderSwan",
+    "wonderswan-color": "WonderSwanColor",  # dedicated folder on MiSTer
+    "wsc":              "WonderSwanColor",
+    # Other consoles
+    "colecovision":     "Coleco",
+    "intellivision":    "Intellivision",
+    "channel-f":        "ChannelF",
+    "channelf":         "ChannelF",
+    "odyssey--1":       "ODYSSEY2",
+    "odyssey2":         "ODYSSEY2",
+    "vectrex":          "VECTREX",
+    "astrocade":        "Astrocade",
+    "arcadia-2001":     "Arcadia",
+    "arcadia":          "Arcadia",
+    "megaduck":         "MegaDuck",
+    "pokemon-mini":     "PokemonMini",
+    "pokemonmini":      "PokemonMini",
+    # Arcade — special (uses .mra files, mostly maintained via update_all)
+    "arcade":           "_Arcade",
+    "mame":             "_Arcade",
+    # Home computers (RomM often lumps these under 'pc' etc.)
+    "c64":              "C64",
+    "commodore-c64":    "C64",
+    "c128":             "C128",
+    "vic-20":           "VIC20",
+    "vic20":            "VIC20",
+    "amiga":            "Amiga",
+    "amstrad-cpc":      "Amstrad",
+    "amstrad":          "Amstrad",
+    "acorn-electron":   "AcornElectron",
+    "bbc-micro":        "BBCMicro",
+    "atari-st":         "AtariST",
+    "atarist":          "AtariST",
+    "msx":              "MSX",
+    "msx2":             "MSX",              # MiSTer's MSX core plays MSX2
+    "sinclair-zx81":    "ZX81",
+    "zx81":             "ZX81",
+    "sinclair-zx-spectrum": "Spectrum",
+    "zxs":              "Spectrum",
+    "zx-spectrum":      "Spectrum",
+    "dos":              "AO486",             # DOS games via the ao486 core
+    "pc-dos":           "AO486",
+    "win3x":            "AO486",             # Windows 3.x runs on ao486
+    "windows-3x":       "AO486",
+    # NOTE: 'win' (Windows 95+) is intentionally NOT mapped — those releases
+    # are too heavy for the ao486 core (limited RAM/CPU). RomM entries tagged
+    # 'win' will show as unsupported.
+    "coleco-adam":      "Adam",
+    "adam":             "Adam",
+    "trs-80":           "TRS-80",
+}
+
+# Slugs we deliberately mark unsupported (RomM has them; MiSTer has no core).
+# Keeping this explicit — an unknown slug is silently unsupported too, but this
+# list is what shows in "you have games for X platforms MiSTer can't run".
+UNSUPPORTED_SLUGS: frozenset[str] = frozenset(
+    {
+        "3do", "3do-interactive-multiplayer",  # partial WIP, not usable
+        "dc", "dreamcast",
+        "gc", "ngc", "gamecube", "nintendo-gamecube",
+        "wii", "nintendo-wii",
+        "wiiu", "nintendo-wii-u",
+        "switch", "nintendo-switch",
+        "3ds", "nintendo-3ds", "new-nintendo-3ds",
+        "nds", "nintendo-ds",
+        "dsi", "nintendo-dsi",
+        "ps2", "playstation-2",
+        "ps3", "playstation-3",
+        "ps4", "playstation-4",
+        "ps5", "playstation-5",
+        "psp", "playstation-portable",
+        "psvita", "playstation-vita",
+        "xbox",
+        "xbox360", "xbox-360",
+        "xboxone", "xbox-one",
+        "series-x-s",
+        "mac", "macintosh",
+        "linux",
+        "android",
+        "ios",
+        "browser",  # Flash / web games
+        "mugen",
+        "win",      # Windows 95+ is too heavy for ao486; deliberately unsupported.
+        "windows",
+    }
+)
+
+
+# User overrides applied at runtime via ``apply_overrides``. Keyed by lowercased
+# slug; empty-string value explicitly disables a slug (renders unsupported).
+_USER_OVERRIDES: dict[str, str] = {}
+
+
+def apply_overrides(overrides: dict | None) -> None:
+    """Replace the runtime override map. Call once at startup and after any edit."""
+    global _USER_OVERRIDES
+    if not isinstance(overrides, dict):
+        _USER_OVERRIDES = {}
+        return
+    _USER_OVERRIDES = {
+        str(k).lower().strip(): str(v or "").strip()
+        for k, v in overrides.items()
+        if k
+    }
+
+
+def core_folder_for_slug(slug: str | None) -> str | None:
+    """Return the MiSTer /media/fat/games/<Core>/ folder name, or None if unsupported.
+
+    User overrides take precedence over the built-in table. An override with an
+    empty value disables the slug (returns None), useful for slugs whose default
+    mapping is wrong for a specific MiSTer setup.
+    """
+    if not slug:
+        return None
+    key = slug.lower().strip()
+    if key in _USER_OVERRIDES:
+        return _USER_OVERRIDES[key] or None
+    return _SLUG_TO_CORE.get(key)
+
+
+def is_supported(slug: str | None) -> bool:
+    return core_folder_for_slug(slug) is not None
+
+
+def games_path(slug: str, filename: str = "", root: str = "/media/fat") -> str | None:
+    """Full remote path for a ROM file, or None if slug is unsupported."""
+    core = core_folder_for_slug(slug)
+    if core is None:
+        return None
+    base = f"{root}/games/{core}"
+    return f"{base}/{filename}" if filename else base
+
+
+def saves_dir(slug: str, root: str = "/media/fat") -> str | None:
+    """MiSTer SRAM save directory for a slug: /media/fat/saves/<Core>/."""
+    core = core_folder_for_slug(slug)
+    if core is None:
+        return None
+    return f"{root}/saves/{core}"
+
+
+def states_dir(slug: str, root: str = "/media/fat") -> str | None:
+    """MiSTer savestate directory for a slug: /media/fat/savestates/<Core>/."""
+    core = core_folder_for_slug(slug)
+    if core is None:
+        return None
+    return f"{root}/savestates/{core}"

--- a/mister-companion/core/romm.py
+++ b/mister-companion/core/romm.py
@@ -1,0 +1,292 @@
+"""Minimal RomM (romm.app) REST client — pairing-code auth.
+
+Auth flow (mirrors decky-romm-sync):
+  1. User generates a short-lived (60s) 8-char pairing code in the RomM web UI
+     (Settings → API Tokens → Pair Device).
+  2. Client does ``POST /api/client-tokens/exchange`` with ``{"code": "..."}`` —
+     public/unauthenticated, one-shot. Response is a ``ClientTokenCreateSchema``
+     whose ``raw_token`` is a long-lived bearer used on every subsequent call.
+  3. Store ``raw_token`` in config; reuse across app launches until revoked in
+     RomM's UI. No username/password ever handled.
+
+Covers the read-only surface the v0 RomM tab needs: whoami, list platforms,
+list ROMs by platform id. Downloads / save sync are out of scope for v0.
+"""
+from __future__ import annotations
+
+import re
+
+import requests
+
+DEFAULT_TIMEOUT = 15
+LIST_TIMEOUT = 60  # /api/roms can be slow on large libraries (thousands of ROMs)
+_PAIR_CODE_RE = re.compile(r"[^A-Za-z0-9]")
+
+
+class RomMError(Exception):
+    pass
+
+
+class RomMPairingError(RomMError):
+    """Pairing-code exchange rejected. ``reason`` is a short machine tag."""
+
+    def __init__(self, message: str, reason: str = "invalid"):
+        super().__init__(message)
+        self.reason = reason
+
+
+def normalize_pairing_code(code: str) -> str:
+    """Strip whitespace/dashes, uppercase, alphanumerics only."""
+    return _PAIR_CODE_RE.sub("", (code or "")).upper()
+
+
+class RomMClient:
+    def __init__(self, base_url: str, token: str = "", verify_tls: bool = True):
+        self.base_url = (base_url or "").strip().rstrip("/")
+        self.verify_tls = verify_tls
+        self.session = requests.Session()
+        self.session.headers.update({"Accept": "application/json"})
+        self._token = token or ""
+        if self._token:
+            self.session.headers["Authorization"] = f"Bearer {self._token}"
+
+    # ── URL helpers ───────────────────────────────────────────────────────
+    def _url(self, path: str) -> str:
+        if not self.base_url:
+            raise RomMError("RomM URL is empty")
+        return f"{self.base_url}{path}"
+
+    @property
+    def token(self) -> str:
+        return self._token
+
+    def set_token(self, token: str) -> None:
+        self._token = token or ""
+        if self._token:
+            self.session.headers["Authorization"] = f"Bearer {self._token}"
+        else:
+            self.session.headers.pop("Authorization", None)
+
+    # ── public / unauthenticated ──────────────────────────────────────────
+    def heartbeat(self) -> dict:
+        r = self.session.get(self._url("/api/heartbeat"), timeout=DEFAULT_TIMEOUT, verify=self.verify_tls)
+        if r.status_code >= 400:
+            raise RomMError(f"Heartbeat failed ({r.status_code}): {r.text[:200]}")
+        return r.json()
+
+    def exchange_pairing_code(self, code: str) -> dict:
+        """One-shot exchange of a 60s pairing code for a Client API Token.
+
+        Public endpoint — the code is itself the credential; no Authorization
+        header is sent. Returns the ClientTokenCreateSchema; ``raw_token`` is
+        the freshly rotated bearer. The client's Bearer header is set as a
+        side effect so subsequent calls are authenticated.
+        """
+        normalized = normalize_pairing_code(code)
+        if not normalized:
+            raise RomMPairingError("Enter a pairing code", reason="empty")
+
+        # Never carry a stale bearer on the exchange call.
+        prior = self.session.headers.pop("Authorization", None)
+        try:
+            r = self.session.post(
+                self._url("/api/client-tokens/exchange"),
+                json={"code": normalized},
+                timeout=DEFAULT_TIMEOUT,
+                verify=self.verify_tls,
+            )
+        except requests.RequestException as exc:
+            if prior:
+                self.session.headers["Authorization"] = prior
+            raise RomMError(f"Cannot reach RomM: {exc}") from exc
+
+        if r.status_code == 404:
+            raise RomMPairingError("Pairing code is invalid or expired", reason="invalid")
+        if r.status_code == 403:
+            raise RomMPairingError("Pairing token owner is disabled", reason="forbidden")
+        if r.status_code == 429:
+            raise RomMPairingError("Too many pairing attempts — wait a minute", reason="rate_limited")
+        if r.status_code >= 400:
+            raise RomMPairingError(f"Exchange failed ({r.status_code}): {r.text[:200]}", reason="server_error")
+
+        payload = r.json()
+        raw = payload.get("raw_token")
+        if not raw:
+            raise RomMPairingError("RomM returned no raw_token", reason="server_error")
+
+        self.set_token(raw)
+        return payload
+
+    # ── authenticated ─────────────────────────────────────────────────────
+    def _authed_get(self, path: str, params: dict | None = None, timeout: int = DEFAULT_TIMEOUT) -> dict | list:
+        if not self._token:
+            raise RomMError("No API token — pair the client first")
+        r = self.session.get(
+            self._url(path),
+            params=params or {},
+            timeout=timeout,
+            verify=self.verify_tls,
+        )
+        if r.status_code == 401:
+            raise RomMError("Token was revoked or is invalid — pair again")
+        if r.status_code == 403:
+            raise RomMError(f"Token lacks the required scope for {path}")
+        if r.status_code >= 400:
+            raise RomMError(f"{path} → HTTP {r.status_code}: {r.text[:200]}")
+        return r.json()
+
+    def whoami(self) -> dict:
+        """Validate the bearer and return the current user."""
+        return self._authed_get("/api/users/me")
+
+    def get_platforms(self) -> list[dict]:
+        data = self._authed_get("/api/platforms")
+        return data if isinstance(data, list) else data.get("items", [])
+
+    def get_collections(self) -> list[dict]:
+        data = self._authed_get("/api/collections")
+        return data if isinstance(data, list) else data.get("items", [])
+
+    def get_firmware(self, platform_id: int) -> list[dict]:
+        """List firmware/BIOS files registered for a platform."""
+        data = self._authed_get("/api/firmware", params={"platform_id": platform_id})
+        return data if isinstance(data, list) else data.get("items", [])
+
+    def stream_firmware(self, firmware_id: int, file_name: str):
+        """Stream a firmware file's raw bytes from RomM."""
+        from urllib.parse import quote
+
+        if not self._token:
+            raise RomMError("No API token — pair the client first")
+        url = self._url(f"/api/firmware/{firmware_id}/content/{quote(file_name, safe='')}")
+        r = self.session.get(url, stream=True, timeout=LIST_TIMEOUT, verify=self.verify_tls)
+        if r.status_code == 401:
+            raise RomMError("Token was revoked or is invalid — pair again")
+        if r.status_code >= 400:
+            raise RomMError(f"Download firmware {file_name} → HTTP {r.status_code}: {r.text[:200]}")
+        return r
+
+    def stream_rom(self, rom_id: int, file_name: str, chunk_size: int = 1024 * 1024):
+        """Stream a ROM file's raw bytes from RomM.
+
+        Returns an iterator of bytes chunks. Caller writes them to a destination
+        (SFTP put file / local file). Uses ``GET /api/roms/{id}/content/{name}``.
+        """
+        from urllib.parse import quote
+
+        if not self._token:
+            raise RomMError("No API token — pair the client first")
+        url = self._url(f"/api/roms/{rom_id}/content/{quote(file_name, safe='')}")
+        r = self.session.get(
+            url,
+            stream=True,
+            timeout=LIST_TIMEOUT,
+            verify=self.verify_tls,
+        )
+        if r.status_code == 401:
+            raise RomMError("Token was revoked or is invalid — pair again")
+        if r.status_code >= 400:
+            raise RomMError(f"Download {file_name} → HTTP {r.status_code}: {r.text[:200]}")
+        return r
+
+    # ── saves / states ────────────────────────────────────────────────────
+    def get_saves(self, rom_id: int) -> list[dict]:
+        data = self._authed_get("/api/saves", params={"rom_id": rom_id})
+        return data if isinstance(data, list) else data.get("items", [])
+
+    def get_states(self, rom_id: int) -> list[dict]:
+        data = self._authed_get("/api/states", params={"rom_id": rom_id})
+        return data if isinstance(data, list) else data.get("items", [])
+
+    def stream_asset(self, asset_kind: str, asset_id: int):
+        """Stream a save (asset_kind='save') or state ('state') file."""
+        if asset_kind not in ("save", "state"):
+            raise RomMError(f"unknown asset_kind {asset_kind!r}")
+        path = f"/api/{asset_kind}s/{asset_id}/content"
+        if not self._token:
+            raise RomMError("No API token — pair the client first")
+        r = self.session.get(self._url(path), stream=True, timeout=LIST_TIMEOUT, verify=self.verify_tls)
+        if r.status_code == 401:
+            raise RomMError("Token was revoked or is invalid — pair again")
+        if r.status_code >= 400:
+            raise RomMError(f"Download {asset_kind} #{asset_id} → HTTP {r.status_code}: {r.text[:200]}")
+        return r
+
+    def upload_asset(
+        self,
+        asset_kind: str,
+        rom_id: int,
+        file_name: str,
+        payload: bytes,
+        emulator: str = "mister",
+        slot: str | None = None,
+    ) -> dict:
+        """POST a new save/state for a ROM. asset_kind: 'save' | 'state'."""
+        if asset_kind not in ("save", "state"):
+            raise RomMError(f"unknown asset_kind {asset_kind!r}")
+        if not self._token:
+            raise RomMError("No API token — pair the client first")
+        params: dict = {"rom_id": rom_id, "emulator": emulator}
+        if slot is not None and asset_kind == "save":
+            params["slot"] = slot
+        field = "saveFile" if asset_kind == "save" else "stateFile"
+        r = self.session.post(
+            self._url(f"/api/{asset_kind}s"),
+            params=params,
+            files={field: (file_name, payload, "application/octet-stream")},
+            timeout=LIST_TIMEOUT,
+            verify=self.verify_tls,
+        )
+        if r.status_code == 401:
+            raise RomMError("Token was revoked or is invalid — pair again")
+        if r.status_code >= 400:
+            raise RomMError(f"Upload {asset_kind} → HTTP {r.status_code}: {r.text[:200]}")
+        return r.json() if r.content else {}
+
+    def update_asset(self, asset_kind: str, asset_id: int, file_name: str, payload: bytes) -> dict:
+        """PUT updated content for an existing save/state."""
+        if asset_kind not in ("save", "state"):
+            raise RomMError(f"unknown asset_kind {asset_kind!r}")
+        if not self._token:
+            raise RomMError("No API token — pair the client first")
+        field = "saveFile" if asset_kind == "save" else "stateFile"
+        r = self.session.put(
+            self._url(f"/api/{asset_kind}s/{asset_id}"),
+            files={field: (file_name, payload, "application/octet-stream")},
+            timeout=LIST_TIMEOUT,
+            verify=self.verify_tls,
+        )
+        if r.status_code == 401:
+            raise RomMError("Token was revoked or is invalid — pair again")
+        if r.status_code >= 400:
+            raise RomMError(f"Update {asset_kind} #{asset_id} → HTTP {r.status_code}: {r.text[:200]}")
+        return r.json() if r.content else {}
+
+    def get_roms(
+        self,
+        *,
+        platform_id: int | None = None,
+        collection_id: int | None = None,
+        limit: int = 5000,
+        offset: int = 0,
+        with_files: bool = False,
+    ) -> list[dict]:
+        """List ROMs filtered by platform or collection.
+
+        RomM's ``/api/roms`` uses ``platform_ids`` (plural) — the singular form is
+        silently ignored, so a bad name returns the whole library and can time out.
+        """
+        params: dict = {
+            "limit": limit,
+            "offset": offset,
+            "order_by": "name",
+            "with_files": "true" if with_files else "false",
+            "with_char_index": "false",
+            "with_filter_values": "false",
+        }
+        if platform_id is not None:
+            params["platform_ids"] = platform_id
+        if collection_id is not None:
+            params["collection_id"] = collection_id
+        data = self._authed_get("/api/roms", params=params, timeout=LIST_TIMEOUT)
+        return data.get("items", data) if isinstance(data, dict) else data

--- a/mister-companion/core/sync.py
+++ b/mister-companion/core/sync.py
@@ -1,0 +1,1008 @@
+"""RomM ↔ MiSTer sync engine.
+
+Two-phase design:
+  1. plan_sync(...)  → walks RomM (subscribed platforms + collections) and the
+     MiSTer /media/fat/games/<Core>/ folders. Returns a SyncPlan bucketing each
+     file into an ActionKind.
+  2. execute_sync(plan, ...) → performs the decisions the UI already resolved.
+
+**Manifest-scoped orphans.** ``plan_sync`` takes a manifest of files this tool
+has previously placed on the MiSTer (keyed by remote path). Only manifested
+files can be ORPHAN candidates — pre-existing user content is invisible to the
+engine. ``execute_sync`` mutates the manifest in place. Callers persist it.
+
+**Manifest v2 shape.** Entries are dicts ``{mtime: float, size: int, hash: str}``
+capturing the last-known state of each placed file. Enables two robustness
+gains: (a) detect intentional RomM deletions — if MiSTer file is unchanged
+since manifest AND RomM has no counterpart, the user deleted it there; don't
+re-upload. (b) short-circuit no-op reconciliations — if MiSTer is unchanged
+and RomM size still matches, skip regardless of ``updated_at`` drift.
+Legacy ``True`` values from older manifests are treated as "we own this but
+lack details" (falls back to weaker checks).
+
+**Read-only subscriptions.** Platforms/collections in the ``readonly_*_ids``
+sets never generate upload actions — RomM is treated as canonical, MiSTer is
+a receive-only mirror.
+
+**Newest-wins for saves/states.** When both sides have a file, compare
+content hash first (RomM ``content_hash`` MD5 vs MiSTer ``md5sum`` over SSH);
+if hashes match → skip. If they differ, compare timestamps (``updated_at`` vs
+``st_mtime``) and auto-pick the newer side. For hashless states with sizes
+matching, an optional streaming byte-hash tie-breaker fetches the RomM asset
+and hashes it locally before deciding to transfer. Prompt only when truly
+ambiguous.
+
+Kinds:
+  ROMs   :  download / overwrite / skip / orphan
+  Saves  :  save_download / save_upload / save_conflict / save_skip
+  States :  state_download / state_upload / state_conflict / state_skip
+"""
+from __future__ import annotations
+
+import hashlib
+import posixpath
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Callable
+
+from core.mister_cores import core_folder_for_slug, saves_dir, states_dir
+
+ActionKind = str
+
+# Timestamps within this window are treated as "equal" (clock skew / rounding).
+_MTIME_TOLERANCE_SECONDS = 5
+
+# UI-side default resolutions (each entry may be overridden per-file):
+RESOLVE_ROMM = "romm"        # keep RomM version (download over local)
+RESOLVE_MISTER = "mister"    # keep MiSTer version (skip)
+RESOLVE_DELETE = "delete"    # delete the orphan on MiSTer
+RESOLVE_KEEP = "keep"        # keep the orphan on MiSTer (do nothing)
+
+
+@dataclass
+class SyncAction:
+    kind: ActionKind
+    core_folder: str
+    remote_path: str                 # on-MiSTer path
+    file_name: str
+    size_romm: int = 0
+    size_mister: int = 0
+    sha1_romm: str = ""
+    rom_id: int | None = None        # None for ROM orphans
+    rom_name: str = ""
+    resolution: str = ""             # UI fills for overwrite / orphan / *_conflict
+    # save/state extras
+    asset_id: int | None = None      # RomM save/state id (None for pure MiSTer→RomM uploads)
+    asset_emulator: str = ""         # RomM emulator tag (e.g. "mister")
+    asset_slot: str = ""             # save slot (states have no slot)
+    asset_updated_at: str = ""       # RomM updated_at ISO — used to sync MiSTer mtime after transfer
+
+
+@dataclass
+class UnsupportedSubscription:
+    kind: str                        # "platform" | "collection"
+    id: int
+    name: str
+    slug: str
+    rom_count: int
+
+
+@dataclass
+class SyncPlan:
+    actions: list[SyncAction] = field(default_factory=list)
+    unsupported: list[UnsupportedSubscription] = field(default_factory=list)
+    # RomM saves/states tagged for another emulator (fceux, retroarch, dolphin…)
+    # — not MiSTer-format, silently filtered out of the download plan.
+    filtered_incompatible: int = 0
+
+    def by_kind(self, kind: ActionKind) -> list[SyncAction]:
+        return [a for a in self.actions if a.kind == kind]
+
+    def totals(self) -> dict[str, int]:
+        return {
+            "download": len(self.by_kind("download")),
+            "overwrite": len(self.by_kind("overwrite")),
+            "skip": len(self.by_kind("skip")),
+            "orphan": len(self.by_kind("orphan")),
+            "save_download": len(self.by_kind("save_download")),
+            "save_upload": len(self.by_kind("save_upload")),
+            "save_conflict": len(self.by_kind("save_conflict")),
+            "save_skip": len(self.by_kind("save_skip")),
+            "state_download": len(self.by_kind("state_download")),
+            "state_upload": len(self.by_kind("state_upload")),
+            "state_conflict": len(self.by_kind("state_conflict")),
+            "state_skip": len(self.by_kind("state_skip")),
+            "unsupported": len(self.unsupported),
+            "bytes_to_download": sum(
+                a.size_romm for a in self.actions if a.kind in ("download", "overwrite")
+            ),
+        }
+
+
+# ── planning ────────────────────────────────────────────────────────────────
+
+def _rom_file_name(rom: dict) -> str:
+    """Best-effort file name for a ROM record.
+
+    Single-file ROMs: ``fs_name`` is the file. Multi-file ROMs (folder-based,
+    e.g. Wii U Loadiine, multi-disc bin/cue): ``fs_name`` is the folder — those
+    aren't handled in Phase A.
+    """
+    return rom.get("fs_name") or rom.get("file_name") or ""
+
+
+def _rom_is_folder(rom: dict) -> bool:
+    """RomM sets multi_file / has_multiple_files for folder-based ROMs."""
+    if rom.get("multi_file"):
+        return True
+    files = rom.get("files") or []
+    return len(files) > 1
+
+
+def _basename(fs_name: str) -> str:
+    """ROM's basename without extension — matches how MiSTer names save files."""
+    dot = fs_name.rfind(".")
+    return fs_name[:dot] if dot > 0 else fs_name
+
+
+def _parse_iso_to_unix(iso: str) -> float | None:
+    if not iso:
+        return None
+    try:
+        t = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        if t.tzinfo is None:
+            t = t.replace(tzinfo=timezone.utc)
+        return t.timestamp()
+    except Exception:
+        return None
+
+
+def _remote_md5(ssh_client, remote_path: str) -> str | None:
+    """Run ``md5sum <path>`` on the MiSTer, return the hex digest or None."""
+    if ssh_client is None:
+        return None
+    try:
+        quoted = "'" + remote_path.replace("'", "'\\''") + "'"
+        _, stdout, _ = ssh_client.exec_command(f"md5sum {quoted} 2>/dev/null")
+        raw = stdout.read().decode("utf-8", errors="ignore").strip()
+        return raw.split()[0] if raw else None
+    except Exception:
+        return None
+
+
+def _romm_asset_md5(client, asset_kind: str, asset_id: int) -> str | None:
+    """Stream a RomM save/state and compute its MD5 client-side.
+
+    Used as a definitive tie-breaker for hashless assets (RomM's states table
+    has no content_hash column) when size + mtime look ambiguous. One transfer
+    per uncertainty — the cost buys us "identical → skip" over "wasted upload/download".
+    """
+    try:
+        resp = client.stream_asset(asset_kind, asset_id)
+        h = hashlib.md5()
+        try:
+            for chunk in resp.iter_content(chunk_size=256 * 1024):
+                if chunk:
+                    h.update(chunk)
+        finally:
+            resp.close()
+        return h.hexdigest()
+    except Exception:
+        return None
+
+
+def _sftp_mkdir_p(sftp, path: str) -> None:
+    """SFTP equivalent of ``mkdir -p`` — handles absolute paths correctly.
+
+    A naive ``path.split('/')`` produces an empty first element for absolute
+    paths, and a `cur = cur + '/' + p if cur else p` accumulator loses the
+    leading slash on the first non-empty segment — files then land under the
+    SSH session's home directory instead of the filesystem root.
+    """
+    if not path or path == "/":
+        return
+    absolute = path.startswith("/")
+    parts = [p for p in path.split("/") if p]
+    cur = "" if not absolute else ""
+    for p in parts:
+        cur = f"{cur}/{p}" if absolute else (f"{cur}/{p}" if cur else p)
+        try:
+            sftp.stat(cur)
+        except (FileNotFoundError, IOError):
+            sftp.mkdir(cur)
+
+
+def _manifest_entry_matches(entry, current_mtime, current_size) -> bool:
+    """True if the manifest entry indicates the MiSTer file is unchanged since
+    last sync. Requires v2 dict entries with concrete mtime+size; legacy ``True``
+    entries return False (we don't know the previous state)."""
+    if not isinstance(entry, dict):
+        return False
+    m_prev = entry.get("mtime")
+    s_prev = entry.get("size")
+    if m_prev is None or s_prev is None or current_mtime is None or current_size is None:
+        return False
+    return abs(float(m_prev) - float(current_mtime)) <= _MTIME_TOLERANCE_SECONDS and int(s_prev) == int(current_size)
+
+
+def _asset_is_mister_compatible(asset: dict) -> bool:
+    """RomM save/state format compatibility gate for MiSTer.
+
+    Save states are strongly emulator-specific (a fceux/retroarch/dolphin state
+    can't be loaded by a MiSTer core). SRAM saves are more portable in theory,
+    but we treat them the same for safety: only assets tagged for MiSTer (or
+    legacy/blank-tagged) are pulled down. Uploads FROM MiSTer are always tagged
+    ``emulator="mister"``, so this filter is naturally consistent.
+    """
+    emu = (asset.get("emulator") or "").strip().lower()
+    return emu == "" or emu == "mister"
+
+
+def _plan_asset_actions(
+    client,
+    rom: dict,
+    core: str,
+    asset_kind: str,             # "save" or "state"
+    remote_dir: str,
+    plan: "SyncPlan",
+    remote_entries: dict[str, int],  # MiSTer basename-matched files: fname → size
+    sftp,
+    ssh_client=None,
+    parent_rom_managed: bool = True,
+    readonly: bool = False,
+    manifest: dict | None = None,
+    mister_root: str = "/media/fat",
+    upload_claimed: dict[str, tuple[int, str]] | None = None,  # remote_path → (rom_id, rom_name)
+    log: Callable[[str], None] | None = None,
+) -> None:
+    """Reconcile one ROM's saves (or states) between RomM and MiSTer.
+
+    Newest-wins logic when a file exists on both sides:
+      1. If MD5 matches → skip
+      2. Else if MiSTer mtime is newer (beyond tolerance) → auto-upload
+      3. Else if RomM updated_at is newer → auto-download
+      4. Else → conflict prompt (user picks)
+    """
+    rom_base = _basename(rom.get("fs_name") or "")
+    if not rom_base:
+        return
+    getter = client.get_saves if asset_kind == "save" else client.get_states
+    try:
+        remote_assets = getter(rom["id"])
+    except Exception:
+        return
+
+    matched_remote_names: set[str] = set()
+
+    for asset in remote_assets or []:
+        fname = asset.get("file_name") or ""
+        if not fname:
+            continue
+        if not _asset_is_mister_compatible(asset):
+            plan.filtered_incompatible += 1
+            matched_remote_names.add(fname)
+            continue
+        matched_remote_names.add(fname)
+        remote_path = f"{remote_dir}/{fname}"
+        r_size = int(asset.get("file_size_bytes") or 0)
+        m_size = remote_entries.get(fname)
+
+        common = dict(
+            core_folder=core, remote_path=remote_path, file_name=fname,
+            rom_id=rom["id"],
+            rom_name=rom.get("name") or rom.get("fs_name") or "",
+            asset_id=asset.get("id"),
+            asset_emulator=str(asset.get("emulator") or ""),
+            asset_slot=str(asset.get("slot") or ""),
+            asset_updated_at=str(asset.get("updated_at") or ""),
+        )
+
+        if m_size is None:
+            plan.actions.append(SyncAction(kind=f"{asset_kind}_download",
+                                           size_romm=r_size, **common))
+            continue
+
+        # Both sides have a file — decide by, in order:
+        #   1. content hash match → skip
+        #   2. manifest says MiSTer unchanged + RomM size unchanged → skip
+        #   3. size + mtime identity → skip
+        #   4. streaming byte-hash (hashless states) → skip if equal
+        #   5. mtime direction → upload/download
+        #   6. hash-less + size match + no timestamps → last-ditch skip
+        #   7. otherwise → conflict prompt
+        r_hash = str(asset.get("content_hash") or "").lower()
+        m_hash = _remote_md5(ssh_client, remote_path)
+        if r_hash and m_hash and r_hash == m_hash:
+            plan.actions.append(SyncAction(kind=f"{asset_kind}_skip",
+                                           size_romm=r_size, size_mister=m_size, **common))
+            continue
+
+        r_ts = _parse_iso_to_unix(asset.get("updated_at") or "")
+        try:
+            m_ts = float(sftp.stat(remote_path).st_mtime)
+        except Exception:
+            m_ts = None
+
+        sizes_match = bool(r_size and m_size == r_size)
+        both_ts = r_ts is not None and m_ts is not None
+
+        # 2. Manifest metadata: if MiSTer file is unchanged since last sync
+        # AND sizes still match, skip. Kills metadata-only bump re-downloads.
+        if manifest is not None and sizes_match:
+            entry = manifest.get(_relpath_key(remote_path, mister_root))
+            if _manifest_entry_matches(entry, m_ts, m_size):
+                plan.actions.append(SyncAction(kind=f"{asset_kind}_skip",
+                                               size_romm=r_size, size_mister=m_size, **common))
+                continue
+
+        # 3. size + mtime identity (post sftp.utime convergence).
+        if sizes_match and both_ts and abs(m_ts - r_ts) <= _MTIME_TOLERANCE_SECONDS:
+            plan.actions.append(SyncAction(kind=f"{asset_kind}_skip",
+                                           size_romm=r_size, size_mister=m_size, **common))
+            continue
+
+        # 4. Streaming byte-hash tie-breaker for hashless assets (states) —
+        # only when sizes match. Costs one MB-scale fetch per uncertain case.
+        if sizes_match and not r_hash and m_hash:
+            streamed = _romm_asset_md5(client, asset_kind, asset.get("id"))
+            if streamed and streamed == m_hash:
+                plan.actions.append(SyncAction(kind=f"{asset_kind}_skip",
+                                               size_romm=r_size, size_mister=m_size, **common))
+                continue
+
+        # 5. Timestamps disagree → follow direction.
+        if both_ts:
+            delta = m_ts - r_ts
+            if delta > _MTIME_TOLERANCE_SECONDS:
+                if readonly:
+                    if log:
+                        log(f"  read-only: MiSTer newer {asset_kind} '{fname}' not uploaded")
+                    plan.actions.append(SyncAction(kind=f"{asset_kind}_skip",
+                                                   size_romm=r_size, size_mister=m_size, **common))
+                else:
+                    plan.actions.append(SyncAction(kind=f"{asset_kind}_upload",
+                                                   size_romm=r_size, size_mister=m_size, **common))
+                continue
+            if delta < -_MTIME_TOLERANCE_SECONDS:
+                plan.actions.append(SyncAction(kind=f"{asset_kind}_download",
+                                               size_romm=r_size, size_mister=m_size, **common))
+                continue
+
+        # 6. Timestamps unusable AND no hashes: size-only skip (weakest signal,
+        # only used when we truly can't check anything else).
+        if not both_ts and sizes_match and not r_hash and not m_hash:
+            plan.actions.append(SyncAction(kind=f"{asset_kind}_skip",
+                                           size_romm=r_size, size_mister=m_size, **common))
+            continue
+
+        # 7. Truly ambiguous → ask the user.
+        plan.actions.append(SyncAction(kind=f"{asset_kind}_conflict",
+                                       size_romm=r_size, size_mister=m_size, **common))
+
+    # MiSTer-side files with no RomM counterpart → upload (tagged emulator=mister).
+    # Gates:
+    #  - parent_rom_managed: don't vacuum saves for pre-existing unmanaged ROMs.
+    #  - readonly: subscription treats RomM as canonical, never uploads.
+    #  - manifest deletion detection: if MiSTer file is UNCHANGED since last
+    #    manifest snapshot and RomM has no counterpart, the user deleted it
+    #    from RomM on purpose — don't re-upload it.
+    if not parent_rom_managed or readonly:
+        return
+    for fname, sz in remote_entries.items():
+        if fname in matched_remote_names or not fname.startswith(rom_base):
+            continue
+        rest = fname[len(rom_base):]
+        if rest and not (rest.startswith(".") or rest.startswith("_")):
+            continue  # e.g. "Mario" would match "Mario 2.sav" — reject
+        remote_path = f"{remote_dir}/{fname}"
+        # Intentional-deletion gate
+        if manifest is not None:
+            key = _relpath_key(remote_path, mister_root)
+            entry = manifest.get(key)
+            if isinstance(entry, dict):
+                try:
+                    cur_mt = float(sftp.stat(remote_path).st_mtime)
+                except Exception:
+                    cur_mt = None
+                if _manifest_entry_matches(entry, cur_mt, sz):
+                    if log:
+                        log(f"  skip re-upload {asset_kind} '{fname}' — MiSTer unchanged, RomM copy was deleted intentionally")
+                    continue
+        # Duplicate-basename guard: if two RomM ROMs share the same basename
+        # (e.g. duplicate imports, dupes across editions), the first ROM to reach
+        # this point owns the upload. Anything else attempting the same file is
+        # skipped + logged, so we never silently attribute one save to two ROMs.
+        if upload_claimed is not None:
+            prior = upload_claimed.get(remote_path)
+            if prior is not None:
+                if log:
+                    log(
+                        f"  ! ambiguous {asset_kind} '{fname}' — attributed to "
+                        f"'{prior[1]}' (rom #{prior[0]}), skipping conflicting "
+                        f"claim by '{rom.get('name') or rom.get('fs_name')}' "
+                        f"(rom #{rom['id']})"
+                    )
+                continue
+            upload_claimed[remote_path] = (rom["id"], rom.get("name") or rom.get("fs_name") or "")
+        slot = ""
+        if asset_kind == "save" and rest.startswith("_"):
+            middle = rest.lstrip("_").split(".", 1)[0]
+            if middle.isdigit():
+                slot = middle
+        plan.actions.append(SyncAction(
+            kind=f"{asset_kind}_upload",
+            core_folder=core,
+            remote_path=remote_path,
+            file_name=fname, size_mister=int(sz),
+            rom_id=rom["id"],
+            rom_name=rom.get("name") or rom.get("fs_name") or "",
+            asset_emulator="mister", asset_slot=slot,
+        ))
+
+
+def _relpath_key(remote_path: str, mister_root: str) -> str:
+    """Compact manifest key: strip the mister_root prefix so hosts survive remount."""
+    if remote_path.startswith(mister_root + "/"):
+        return remote_path[len(mister_root) + 1:]
+    return remote_path
+
+
+def plan_sync(
+    client,
+    *,
+    subscribed_platform_ids: list[int],
+    subscribed_collection_ids: list[int],
+    readonly_platform_ids: list[int] | None = None,
+    readonly_collection_ids: list[int] | None = None,
+    sftp,
+    ssh_client=None,
+    manifest: dict | None = None,
+    mister_root: str = "/media/fat",
+    include_assets: bool = False,
+    progress: Callable[[str], None] | None = None,
+) -> SyncPlan:
+    """Compute a SyncPlan against a live RomM + live SFTP session.
+
+    ``mister_root`` is the SD/USB mount base (default /media/fat). Games live at
+    ``<mister_root>/games/<Core>/``; saves/states at ``<mister_root>/{saves,savestates}/<Core>/``.
+    Enable ``include_assets`` to also reconcile saves and states per ROM.
+
+    ``manifest`` (per-MiSTer, keyed by ``<subpath>`` under ``mister_root``) records
+    every file this tool has placed on the device. Orphan detection ONLY considers
+    files present in the manifest — pre-existing user content is left alone.
+    ``ssh_client`` (paramiko SSHClient) is used for remote ``md5sum`` during
+    save/state hash comparison; if None, hash-check is skipped.
+    """
+    games_root = f"{mister_root}/games"
+    manifest = manifest or {}
+    readonly_platform_ids = set(readonly_platform_ids or [])
+    readonly_collection_ids = set(readonly_collection_ids or [])
+    # Track which cores derive from at least one read-only subscription. A core
+    # in this set will suppress uploads (readonly wins if any source subscription
+    # is readonly — safer default).
+    readonly_cores: set[str] = set()
+    plan = SyncPlan()
+    log = progress or (lambda _s: None)
+
+    # ── build RomM-side wishlist (rom + core_folder), grouped by core ───────
+    wanted_per_core: dict[str, list[dict]] = {}
+    covered_cores: set[str] = set()
+
+    platforms = {p["id"]: p for p in client.get_platforms()}
+
+    for pid in subscribed_platform_ids:
+        p = platforms.get(pid)
+        if not p:
+            log(f"platform #{pid} no longer exists on RomM — skipping")
+            continue
+        core = core_folder_for_slug(p.get("slug"))
+        if core is None:
+            plan.unsupported.append(
+                UnsupportedSubscription("platform", pid, p.get("name", ""), p.get("slug", ""),
+                                        int(p.get("rom_count") or 0))
+            )
+            continue
+        covered_cores.add(core)
+        if pid in readonly_platform_ids:
+            readonly_cores.add(core)
+        log(f"listing RomM platform: {p.get('name')} ({p.get('rom_count', '?')})")
+        roms = client.get_roms(platform_id=pid)
+        for rom in roms:
+            wanted_per_core.setdefault(core, []).append(rom)
+
+    # Collections can span platforms — resolve per-ROM
+    for cid in subscribed_collection_ids:
+        log(f"listing RomM collection #{cid}")
+        roms = client.get_roms(collection_id=cid)
+        for rom in roms:
+            slug = (rom.get("platform_fs_slug") or rom.get("platform_slug") or "").lower()
+            core = core_folder_for_slug(slug)
+            if core is None:
+                if not any(u.slug == slug and u.kind == "collection" and u.id == cid for u in plan.unsupported):
+                    plan.unsupported.append(
+                        UnsupportedSubscription("collection", cid, rom.get("platform_name") or slug, slug, 0)
+                    )
+                continue
+            covered_cores.add(core)
+            if cid in readonly_collection_ids:
+                readonly_cores.add(core)
+            wanted_per_core.setdefault(core, []).append(rom)
+
+    # ── walk MiSTer /media/fat/games/<Core>/ for each core we care about ────
+    remote_per_core: dict[str, dict[str, int]] = {}
+    for core in sorted(covered_cores):
+        path = f"{games_root}/{core}"
+        entries: dict[str, int] = {}
+        try:
+            for attr in sftp.listdir_attr(path):
+                # skip subdirs (multi-file / folder ROMs handled Phase B)
+                if attr.st_mode is not None and attr.st_mode & 0o170000 == 0o040000:
+                    continue
+                entries[attr.filename] = int(attr.st_size or 0)
+        except (FileNotFoundError, IOError) as exc:
+            # MiSTer may not have the folder yet — that's fine, we'll create it
+            log(f"MiSTer folder {path} is empty or missing ({exc.__class__.__name__})")
+        remote_per_core[core] = entries
+
+    # ── produce actions ────────────────────────────────────────────────────
+    for core, roms in wanted_per_core.items():
+        remote_files = remote_per_core.get(core, {})
+        seen_files: set[str] = set()
+
+        for rom in roms:
+            if _rom_is_folder(rom):
+                # Phase A: skip folder-based ROMs. Log once.
+                log(f"skip (multi-file): {rom.get('name') or rom.get('fs_name')}")
+                continue
+            fname = _rom_file_name(rom)
+            if not fname:
+                continue
+            if fname in seen_files:
+                # duplicated across platform + collection subscriptions — dedupe
+                continue
+            seen_files.add(fname)
+
+            size_romm = int(rom.get("fs_size_bytes") or 0)
+            # sha1: prefer files[0].sha1_hash, fall back to top-level if present
+            sha1 = ""
+            files = rom.get("files") or []
+            if files:
+                sha1 = str(files[0].get("sha1_hash") or "")
+            sha1 = sha1 or str(rom.get("sha1_hash") or "")
+
+            remote_size = remote_files.get(fname)
+            remote_path = f"{games_root}/{core}/{fname}"
+
+            if remote_size is None:
+                plan.actions.append(SyncAction(
+                    kind="download",
+                    core_folder=core,
+                    remote_path=remote_path,
+                    file_name=fname,
+                    size_romm=size_romm,
+                    sha1_romm=sha1,
+                    rom_id=rom.get("id"),
+                    rom_name=rom.get("name") or fname,
+                ))
+            elif size_romm and remote_size == size_romm:
+                # size match — treat as identical (Phase A: skip remote sha1sum RPC).
+                plan.actions.append(SyncAction(
+                    kind="skip",
+                    core_folder=core,
+                    remote_path=remote_path,
+                    file_name=fname,
+                    size_romm=size_romm,
+                    size_mister=remote_size,
+                    sha1_romm=sha1,
+                    rom_id=rom.get("id"),
+                    rom_name=rom.get("name") or fname,
+                ))
+            else:
+                # size mismatch (or RomM size unknown) — UI must ask
+                plan.actions.append(SyncAction(
+                    kind="overwrite",
+                    core_folder=core,
+                    remote_path=remote_path,
+                    file_name=fname,
+                    size_romm=size_romm,
+                    size_mister=remote_size,
+                    sha1_romm=sha1,
+                    rom_id=rom.get("id"),
+                    rom_name=rom.get("name") or fname,
+                ))
+
+        # Files on MiSTer not in the wishlist COULD be orphans — but only if
+        # this tool placed them there (manifest-scoped). Pre-existing files the
+        # user built up over years are invisible to orphan detection.
+        wanted_names = {_rom_file_name(r) for r in roms if not _rom_is_folder(r)}
+        for fname, rsize in remote_files.items():
+            if fname in wanted_names:
+                continue
+            remote_path = f"{games_root}/{core}/{fname}"
+            if _relpath_key(remote_path, mister_root) not in manifest:
+                continue  # pre-existing user content — leave alone
+            plan.actions.append(SyncAction(
+                kind="orphan",
+                core_folder=core,
+                remote_path=remote_path,
+                file_name=fname,
+                size_mister=int(rsize),
+            ))
+
+    # Compute the set of ROM paths this run will consider "managed" — either
+    # already in the manifest OR being touched by a download/skip/overwrite
+    # action this sync. Used to gate save/state uploads: saves for a pre-existing
+    # unmanaged ROM must not be silently vacuumed into RomM.
+    managed_rom_paths: set[str] = set(manifest.keys())
+    for a in plan.actions:
+        if a.kind in ("download", "skip", "overwrite"):
+            managed_rom_paths.add(_relpath_key(a.remote_path, mister_root))
+
+    # ── save/state reconciliation (opt-in) ─────────────────────────────
+    # Track upload attributions across all ROMs so duplicate-basename ROMs
+    # don't both "claim" the same MiSTer file. Keyed by remote_path per asset kind.
+    save_claims: dict[str, tuple[int, str]] = {}
+    state_claims: dict[str, tuple[int, str]] = {}
+    if include_assets:
+        # Walk each subscribed ROM once; skip folder-ROMs (Phase A).
+        # Cache per-slug MiSTer directory listings so we don't re-list per rom.
+        saves_listing: dict[str, dict[str, int]] = {}
+        states_listing: dict[str, dict[str, int]] = {}
+
+        def _listdir_cached(cache: dict, path: str) -> dict[str, int]:
+            if path in cache:
+                return cache[path]
+            entries: dict[str, int] = {}
+            try:
+                for attr in sftp.listdir_attr(path):
+                    if attr.st_mode and attr.st_mode & 0o170000 == 0o040000:
+                        continue
+                    entries[attr.filename] = int(attr.st_size or 0)
+            except (FileNotFoundError, IOError):
+                pass
+            cache[path] = entries
+            return entries
+
+        for core, roms in wanted_per_core.items():
+            # locate a matching slug just so we can derive save/state dirs
+            slug_for_core = None
+            for pid in subscribed_platform_ids:
+                p = platforms.get(pid)
+                if p and core_folder_for_slug(p.get("slug")) == core:
+                    slug_for_core = p.get("slug"); break
+            # (collections have per-rom slugs, so also try from any rom)
+            if not slug_for_core and roms:
+                slug_for_core = (roms[0].get("platform_fs_slug")
+                                 or roms[0].get("platform_slug") or "")
+            sdir = saves_dir(slug_for_core or "", root=mister_root)
+            tdir = states_dir(slug_for_core or "", root=mister_root)
+            if not sdir or not tdir:
+                continue
+            s_entries = _listdir_cached(saves_listing, sdir)
+            t_entries = _listdir_cached(states_listing, tdir)
+
+            # Only consider entries matching the ROMs' basenames in this core
+            # (avoids uploading orphaned MiSTer saves for unsubscribed ROMs).
+            for rom in roms:
+                if _rom_is_folder(rom):
+                    continue
+                rom_base = _basename(rom.get("fs_name") or "")
+                if not rom_base:
+                    continue
+                s_for_rom = {n: sz for n, sz in s_entries.items()
+                             if n == rom_base or n.startswith(rom_base + ".") or n.startswith(rom_base + "_")}
+                t_for_rom = {n: sz for n, sz in t_entries.items()
+                             if n == rom_base or n.startswith(rom_base + ".") or n.startswith(rom_base + "_")}
+                rom_key = _relpath_key(f"{games_root}/{core}/{rom.get('fs_name') or ''}", mister_root)
+                parent_managed = rom_key in managed_rom_paths
+                core_readonly = core in readonly_cores
+                _plan_asset_actions(client, rom, core, "save",  sdir, plan, s_for_rom,
+                                    sftp=sftp, ssh_client=ssh_client,
+                                    parent_rom_managed=parent_managed,
+                                    readonly=core_readonly,
+                                    manifest=manifest, mister_root=mister_root,
+                                    upload_claimed=save_claims, log=log)
+                _plan_asset_actions(client, rom, core, "state", tdir, plan, t_for_rom,
+                                    sftp=sftp, ssh_client=ssh_client,
+                                    parent_rom_managed=parent_managed,
+                                    readonly=core_readonly,
+                                    manifest=manifest, mister_root=mister_root,
+                                    upload_claimed=state_claims, log=log)
+
+    return plan
+
+
+# ── execution ──────────────────────────────────────────────────────────────
+
+def download_and_push(
+    client,
+    sftp,
+    rom_id: int,
+    file_name: str,
+    remote_path: str,
+    progress: Callable[[int, int], None] | None = None,
+) -> int:
+    """Stream one RomM ROM directly into an SFTP file on the MiSTer.
+
+    Returns the bytes written. ``progress`` (if given) is called with
+    (bytes_written, total_bytes_or_zero) after each chunk.
+    """
+    _sftp_mkdir_p(sftp, posixpath.dirname(remote_path))
+
+    written = 0
+    resp = client.stream_rom(rom_id, file_name)
+    total = int(resp.headers.get("Content-Length") or 0)
+    tmp = remote_path + ".part"
+    try:
+        with sftp.open(tmp, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=1024 * 1024):
+                if not chunk:
+                    continue
+                f.write(chunk)
+                written += len(chunk)
+                if progress:
+                    progress(written, total)
+        sftp.posix_rename(tmp, remote_path) if hasattr(sftp, "posix_rename") else sftp.rename(tmp, remote_path)
+    finally:
+        resp.close()
+    return written
+
+
+def _sync_mtime_to_updated_at(sftp, remote_path: str, updated_at_iso: str) -> None:
+    """After any transfer, force MiSTer file mtime to match RomM's updated_at.
+
+    This lets the planner recognise "same content" via size+mtime identity, which
+    matters for states (RomM's states schema has no content_hash column).
+    """
+    ts = _parse_iso_to_unix(updated_at_iso)
+    if ts is None:
+        return
+    try:
+        sftp.utime(remote_path, (ts, ts))
+    except Exception:
+        pass  # non-fatal — worst case is a redundant sync next round
+
+
+def _download_asset(client, sftp, asset_kind: str, action: SyncAction) -> None:
+    """Stream a RomM save/state into an SFTP file (with mkdir -p)."""
+    _sftp_mkdir_p(sftp, posixpath.dirname(action.remote_path))
+    resp = client.stream_asset(asset_kind, action.asset_id)
+    tmp = action.remote_path + ".part"
+    try:
+        with sftp.open(tmp, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=256 * 1024):
+                if chunk:
+                    f.write(chunk)
+        rename = sftp.posix_rename if hasattr(sftp, "posix_rename") else sftp.rename
+        rename(tmp, action.remote_path)
+    finally:
+        resp.close()
+    _sync_mtime_to_updated_at(sftp, action.remote_path, action.asset_updated_at)
+
+
+def _upload_asset(client, sftp, asset_kind: str, action: SyncAction) -> None:
+    """Read a MiSTer save/state via SFTP, POST/PUT it to RomM.
+
+    Then set the MiSTer file's mtime to the server-returned updated_at so the
+    next sync recognises them as identical (essential for hash-less states).
+    """
+    with sftp.open(action.remote_path, "rb") as f:
+        payload = f.read()
+    if action.asset_id is not None:
+        resp = client.update_asset(asset_kind, action.asset_id, action.file_name, payload)
+    else:
+        resp = client.upload_asset(
+            asset_kind,
+            action.rom_id,
+            action.file_name,
+            payload,
+            emulator=action.asset_emulator or "mister",
+            slot=action.asset_slot or None,
+        )
+    _sync_mtime_to_updated_at(sftp, action.remote_path, (resp or {}).get("updated_at", ""))
+
+
+def download_firmware_for_platform(
+    client,
+    sftp,
+    *,
+    platform_id: int,
+    platform_slug: str,
+    mister_root: str = "/media/fat",
+    progress: Callable[[str], None] | None = None,
+) -> dict:
+    """Pull all firmware registered for a platform into ``<mister_root>/games/<Core>/bios/``.
+
+    Explicit user action (not part of Sync Now). Skips files whose size on MiSTer
+    already matches RomM; otherwise streams with a ``.part`` staging file +
+    atomic rename. Returns counters. NOT tracked in the manifest — BIOS is
+    set-once-and-forget by design; user re-runs this action to refresh.
+    """
+    log = progress or (lambda _s: None)
+    stats = {"downloaded": 0, "skipped": 0, "errors": 0, "bytes": 0}
+    core = core_folder_for_slug(platform_slug)
+    if core is None:
+        log(f"! platform '{platform_slug}' has no MiSTer core — skipping BIOS download")
+        return stats
+    remote_dir = f"{mister_root}/games/{core}/bios"
+
+    try:
+        firmware = client.get_firmware(platform_id) or []
+    except Exception as exc:
+        log(f"! fetch firmware list failed: {exc}")
+        stats["errors"] += 1
+        return stats
+    if not firmware:
+        log(f"no firmware in RomM for platform '{platform_slug}' (core: {core})")
+        return stats
+
+    log(f"↓ {len(firmware)} BIOS file(s) → {remote_dir}/")
+
+    try:
+        _sftp_mkdir_p(sftp, remote_dir)
+    except Exception as exc:
+        log(f"! mkdir {remote_dir} failed: {exc}")
+        stats["errors"] += 1
+        return stats
+
+    for fw in firmware:
+        fname = fw.get("file_name") or ""
+        fid = fw.get("id")
+        r_size = int(fw.get("file_size_bytes") or 0)
+        if not fname or fid is None:
+            continue
+        remote_path = f"{remote_dir}/{fname}"
+
+        # Skip if already present with matching size
+        try:
+            m_size = int(sftp.stat(remote_path).st_size or 0)
+            if r_size and m_size == r_size:
+                log(f"  = {fname} (unchanged, {r_size} B)")
+                stats["skipped"] += 1
+                continue
+        except (FileNotFoundError, IOError):
+            pass
+
+        tmp = remote_path + ".part"
+        try:
+            resp = client.stream_firmware(fid, fname)
+            try:
+                with sftp.open(tmp, "wb") as f:
+                    for chunk in resp.iter_content(chunk_size=256 * 1024):
+                        if chunk:
+                            f.write(chunk)
+            finally:
+                resp.close()
+            rename = sftp.posix_rename if hasattr(sftp, "posix_rename") else sftp.rename
+            rename(tmp, remote_path)
+            log(f"  ↓ {fname} ({r_size} B)")
+            stats["downloaded"] += 1
+            stats["bytes"] += r_size
+        except Exception as exc:
+            log(f"  ! {fname}: {exc}")
+            stats["errors"] += 1
+    return stats
+
+
+def execute_sync(
+    plan: SyncPlan,
+    client,
+    sftp,
+    *,
+    ssh_client=None,
+    manifest: dict | None = None,
+    mister_root: str = "/media/fat",
+    progress: Callable[[str], None] | None = None,
+) -> dict:
+    """Perform the resolved plan. Returns a counters dict.
+
+    Mutates ``manifest`` in place with v2 entries ``{mtime,size,hash}``.
+    """
+    log = progress or (lambda _s: None)
+    manifest = manifest if manifest is not None else {}
+    stats = {
+        "downloaded": 0, "overwritten": 0, "deleted": 0, "skipped": 0, "kept": 0,
+        "saves_down": 0, "saves_up": 0, "saves_skip": 0,
+        "states_down": 0, "states_up": 0, "states_skip": 0,
+        "errors": 0,
+    }
+
+    def _snapshot(remote_path: str) -> dict:
+        """Read post-transfer mtime+size (+ hash if cheap) for the manifest."""
+        entry: dict = {}
+        try:
+            st = sftp.stat(remote_path)
+            entry["mtime"] = float(st.st_mtime)
+            entry["size"] = int(st.st_size or 0)
+        except Exception:
+            pass
+        h = _remote_md5(ssh_client, remote_path)
+        if h:
+            entry["hash"] = h
+        return entry
+
+    def _mark_placed(a: SyncAction) -> None:
+        manifest[_relpath_key(a.remote_path, mister_root)] = _snapshot(a.remote_path)
+
+    def _mark_removed(a: SyncAction) -> None:
+        manifest.pop(_relpath_key(a.remote_path, mister_root), None)
+
+    for a in plan.actions:
+        try:
+            if a.kind == "skip":
+                stats["skipped"] += 1
+                # Ensure files that already match are still tracked as ours,
+                # so a later unsubscribe can prune them.
+                _mark_placed(a)
+                continue
+
+            if a.kind == "download":
+                log(f"↓ {a.rom_name}  ({a.size_romm} B)")
+                download_and_push(client, sftp, a.rom_id, a.file_name, a.remote_path)
+                _mark_placed(a); stats["downloaded"] += 1
+
+            elif a.kind == "overwrite":
+                if a.resolution == RESOLVE_ROMM:
+                    log(f"↓ overwrite {a.rom_name}")
+                    download_and_push(client, sftp, a.rom_id, a.file_name, a.remote_path)
+                    _mark_placed(a); stats["overwritten"] += 1
+                elif a.resolution == RESOLVE_MISTER:
+                    log(f"= keep MiSTer copy of {a.file_name}")
+                    stats["skipped"] += 1
+                else:
+                    log(f"?  unresolved overwrite for {a.file_name} — skipping")
+                    stats["errors"] += 1
+
+            elif a.kind == "orphan":
+                if a.resolution == RESOLVE_DELETE:
+                    log(f"× delete orphan {a.remote_path}")
+                    try:
+                        sftp.remove(a.remote_path)
+                        _mark_removed(a); stats["deleted"] += 1
+                    except (FileNotFoundError, IOError) as exc:
+                        log(f"  remove failed: {exc}")
+                        stats["errors"] += 1
+                elif a.resolution == RESOLVE_KEEP:
+                    stats["kept"] += 1
+                else:
+                    log(f"?  unresolved orphan {a.file_name} — keeping")
+                    stats["kept"] += 1
+
+            # ── SAVES / STATES ────────────────────────────────────────
+            elif a.kind in ("save_skip", "state_skip"):
+                stats["saves_skip" if a.kind == "save_skip" else "states_skip"] += 1
+                _mark_placed(a)
+
+            elif a.kind == "save_download":
+                log(f"↓ save {a.file_name}"); _download_asset(client, sftp, "save", a)
+                _mark_placed(a); stats["saves_down"] += 1
+            elif a.kind == "state_download":
+                log(f"↓ state {a.file_name}"); _download_asset(client, sftp, "state", a)
+                _mark_placed(a); stats["states_down"] += 1
+
+            elif a.kind == "save_upload":
+                log(f"↑ save {a.file_name}");  _upload_asset(client, sftp, "save", a)
+                stats["saves_up"] += 1  # uploads don't touch MiSTer, no manifest change
+            elif a.kind == "state_upload":
+                log(f"↑ state {a.file_name}"); _upload_asset(client, sftp, "state", a)
+                stats["states_up"] += 1
+
+            elif a.kind in ("save_conflict", "state_conflict"):
+                asset_kind = "save" if a.kind == "save_conflict" else "state"
+                if a.resolution == RESOLVE_ROMM:
+                    log(f"↓ {asset_kind} conflict → RomM wins {a.file_name}")
+                    _download_asset(client, sftp, asset_kind, a)
+                    _mark_placed(a)
+                    stats["saves_down" if asset_kind == "save" else "states_down"] += 1
+                elif a.resolution == RESOLVE_MISTER:
+                    log(f"↑ {asset_kind} conflict → MiSTer wins {a.file_name}")
+                    _upload_asset(client, sftp, asset_kind, a)
+                    stats["saves_up" if asset_kind == "save" else "states_up"] += 1
+                else:
+                    log(f"?  unresolved {asset_kind} conflict {a.file_name} — skipping")
+                    stats["errors"] += 1
+        except Exception as exc:
+            log(f"! {a.file_name}: {exc}")
+            stats["errors"] += 1
+
+    return stats

--- a/mister-companion/ui/main_window.py
+++ b/mister-companion/ui/main_window.py
@@ -66,6 +66,7 @@ from ui.tabs.device_tab import DeviceTab
 from ui.tabs.flash_tab import FlashTab
 from ui.tabs.install_center_tab import InstallCenterTab
 from ui.tabs.mister_settings_tab import MiSTerSettingsTab
+from ui.tabs.romm_tab import RomMTab
 from ui.tabs.savemanager_tab import SaveManagerTab
 from ui.tabs.wallpapers_tab import WallpapersTab
 from ui.tabs.zapscraper_tab import ZapScraperTab
@@ -637,6 +638,13 @@ class MainWindow(QMainWindow):
             "SaveManager",
         )
 
+        self.romm_tab = RomMTab(self)
+        self.tabs.addTab(
+            self.romm_tab,
+            self.tab_icon("zapscripts"),
+            "RomM",
+        )
+
         self.wallpapers_tab = WallpapersTab(self)
 
         self.build_side_menu()
@@ -674,6 +682,7 @@ class MainWindow(QMainWindow):
             ("ZapScripts", "zapscripts"),
             ("ZapScraper", "zapscripts"),
             ("SaveManager", "savemanager"),
+            ("RomM", "zapscripts"),
         ]
 
     def current_menu_style(self) -> str:

--- a/mister-companion/ui/tabs/romm_tab.py
+++ b/mister-companion/ui/tabs/romm_tab.py
@@ -1,0 +1,1332 @@
+"""RomM integration tab.
+
+Two authentication states (unpaired vs paired), and inside the paired state
+three sub-tabs:
+  - Browse     — platforms + collections + ROM table (right-click for actions)
+  - Sync       — manage subscriptions and run the RomM ↔ MiSTer sync
+  - Log        — persistent activity log
+
+Auth = pairing-code exchange (mirrors decky-romm-sync).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from PyQt6.QtCore import QThread, Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QAbstractItemView,
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QInputDialog,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMenu,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QRadioButton,
+    QSplitter,
+    QStackedWidget,
+    QTableWidget,
+    QTableWidgetItem,
+    QTabWidget,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from core.config import save_config
+from core.mister_cores import apply_overrides as apply_core_overrides
+from core.mister_cores import core_folder_for_slug, is_supported
+from core.romm import RomMClient, RomMError, RomMPairingError, normalize_pairing_code
+from core.sync import (
+    RESOLVE_DELETE,
+    RESOLVE_KEEP,
+    RESOLVE_MISTER,
+    RESOLVE_ROMM,
+    SyncPlan,
+    download_and_push,
+    download_firmware_for_platform,
+    execute_sync,
+    plan_sync,
+)
+
+
+def _human_size(n) -> str:
+    if not n:
+        return ""
+    try:
+        n = float(n)
+    except Exception:
+        return str(n)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if n < 1024:
+            return f"{n:.1f} {unit}" if unit != "B" else f"{int(n)} {unit}"
+        n /= 1024
+    return f"{n:.1f} PB"
+
+
+def _relative_time(iso: str) -> str:
+    try:
+        t = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        if t.tzinfo is None:
+            t = t.replace(tzinfo=timezone.utc)
+    except Exception:
+        return iso
+    delta = datetime.now(timezone.utc) - t
+    secs = int(delta.total_seconds())
+    if secs < 60:
+        return "just now"
+    if secs < 3600:
+        return f"{secs // 60}m ago"
+    if secs < 86400:
+        return f"{secs // 3600}h ago"
+    return f"{secs // 86400}d ago"
+
+
+# ── generic worker ─────────────────────────────────────────────────────────
+class RomMWorker(QThread):
+    finished = pyqtSignal(bool, object)
+    progress = pyqtSignal(str)
+
+    def __init__(self, fn):
+        super().__init__()
+        self.fn = fn
+
+    def run(self):
+        try:
+            self.finished.emit(True, self.fn(self.progress.emit))
+        except Exception as exc:
+            self.finished.emit(False, exc)
+
+
+# ── decision dialogs ───────────────────────────────────────────────────────
+class OrphanDecisionDialog(QDialog):
+    """Ask the user what to do with files on MiSTer that aren't in any subscription."""
+
+    def __init__(self, orphans, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Files on MiSTer that aren't in your subscriptions")
+        self.setMinimumSize(720, 460)
+        self.resolution = ""
+
+        layout = QVBoxLayout(self)
+        info = QLabel(
+            f"<b>{len(orphans)}</b> file(s) exist on the MiSTer but aren't in any "
+            "platform or collection you're syncing. What do you want to do?"
+        )
+        info.setWordWrap(True)
+        layout.addWidget(info)
+
+        self.list = QListWidget()
+        self.list.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
+        for a in orphans:
+            self.list.addItem(f"{a.core_folder}/{a.file_name}   ({_human_size(a.size_mister)})")
+        layout.addWidget(self.list, 1)
+
+        self.keep_radio = QRadioButton("Keep all — do nothing to these files")
+        self.delete_radio = QRadioButton("Delete all — remove them from the MiSTer")
+        self.keep_radio.setChecked(True)
+        layout.addWidget(self.keep_radio)
+        layout.addWidget(self.delete_radio)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons.accepted.connect(self._accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _accept(self):
+        self.resolution = RESOLVE_DELETE if self.delete_radio.isChecked() else RESOLVE_KEEP
+        self.accept()
+
+
+class OverwriteDecisionDialog(QDialog):
+    """Ask the user what to do with files that differ between MiSTer and RomM."""
+
+    def __init__(self, conflicts, parent=None, title="Files differ between MiSTer and RomM"):
+        super().__init__(parent)
+        self.setWindowTitle(title)
+        self.setMinimumSize(760, 460)
+        self.resolution = ""
+
+        layout = QVBoxLayout(self)
+        info = QLabel(
+            f"<b>{len(conflicts)}</b> file(s) exist on both sides but have different "
+            "sizes. Which side should win?"
+        )
+        info.setWordWrap(True)
+        layout.addWidget(info)
+
+        self.list = QListWidget()
+        self.list.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
+        for a in conflicts:
+            self.list.addItem(
+                f"{a.core_folder}/{a.file_name}   "
+                f"MiSTer: {_human_size(a.size_mister)}   RomM: {_human_size(a.size_romm)}"
+            )
+        layout.addWidget(self.list, 1)
+
+        self.romm_radio = QRadioButton("RomM wins — download over the MiSTer copy")
+        self.mister_radio = QRadioButton("MiSTer wins — skip these downloads")
+        self.romm_radio.setChecked(True)
+        layout.addWidget(self.romm_radio)
+        layout.addWidget(self.mister_radio)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons.accepted.connect(self._accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _accept(self):
+        self.resolution = RESOLVE_ROMM if self.romm_radio.isChecked() else RESOLVE_MISTER
+        self.accept()
+
+
+# ── main tab ───────────────────────────────────────────────────────────────
+class RomMTab(QWidget):
+    def __init__(self, main_window):
+        super().__init__()
+        self.main_window = main_window
+        self._worker: RomMWorker | None = None
+        self._rom_worker: RomMWorker | None = None
+        self._client: RomMClient | None = None
+        self._platforms: list[dict] = []
+        self._collections: list[dict] = []
+        self._mister_was_connected: bool = False
+        self._sync_in_progress: bool = False
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(12, 12, 12, 12)
+        root.setSpacing(10)
+
+        # Two auth panes, either visible at once. Kept in the root layout so
+        # the hidden one collapses to zero height (unlike a QStackedWidget,
+        # which reserves the tallest child's height).
+        self.unpaired_pane = self._build_unpaired_pane()
+        self.paired_pane = self._build_paired_pane()
+        root.addWidget(self.unpaired_pane)
+        root.addWidget(self.paired_pane)
+        self.paired_pane.hide()
+
+        self.main_tabs = QTabWidget()
+        self.main_tabs.addTab(self._build_browse_tab(), "Browse")
+        self.main_tabs.addTab(self._build_sync_tab(), "Sync")
+        self.main_tabs.addTab(self._build_log_tab(), "Log")
+        root.addWidget(self.main_tabs, 1)
+
+        # Apply any user overrides for the slug→core mapping BEFORE we start
+        # rendering / planning.
+        apply_core_overrides(self._cfg("core_overrides", {}))
+        self._restore_from_config()
+
+    # ── AUTH panes ────────────────────────────────────────────────────────
+    def _build_unpaired_pane(self) -> QWidget:
+        pane = QGroupBox("Pair with RomM")
+        layout = QVBoxLayout(pane)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(8)
+
+        help_lbl = QLabel(
+            "In your RomM web UI, open <b>Control Panel → API Keys</b>, generate a "
+            "<b>pairing code</b> (60s validity), then paste the 8-character code below."
+        )
+        help_lbl.setWordWrap(True)
+        layout.addWidget(help_lbl)
+
+        url_cfg = self.main_window.config_data.get("romm_config", {}).get("url", "")
+        self.url_edit = QLineEdit(url_cfg)
+        self.url_edit.setPlaceholderText("https://romm.example.com")
+        for label, w in (("URL", self.url_edit),):
+            row = QHBoxLayout()
+            lbl = QLabel(label); lbl.setFixedWidth(80)
+            row.addWidget(lbl); row.addWidget(w, 1); layout.addLayout(row)
+
+        self.code_edit = QLineEdit()
+        self.code_edit.setPlaceholderText("XXXXXXXX")
+        self.code_edit.setMaxLength(16)
+        self.code_edit.textChanged.connect(self._normalize_code_field)
+        row = QHBoxLayout()
+        lbl = QLabel("Pair code"); lbl.setFixedWidth(80)
+        row.addWidget(lbl); row.addWidget(self.code_edit, 1); layout.addLayout(row)
+
+        btn_row = QHBoxLayout(); btn_row.addStretch()
+        self.pair_button = QPushButton("Pair"); self.pair_button.setDefault(True)
+        self.pair_button.clicked.connect(self._on_pair)
+        btn_row.addWidget(self.pair_button); layout.addLayout(btn_row)
+        return pane
+
+    def _build_paired_pane(self) -> QWidget:
+        # Flat one-line bar — no groupbox, tight margins.
+        pane = QWidget()
+        layout = QHBoxLayout(pane)
+        layout.setContentsMargins(4, 2, 4, 2)
+        layout.setSpacing(6)
+        self.paired_label = QLabel()
+        self.paired_label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        layout.addWidget(self.paired_label, 1)
+        self.refresh_button = QPushButton("Refresh")
+        self.refresh_button.setFlat(True)
+        self.refresh_button.clicked.connect(self._on_refresh_lists)
+        layout.addWidget(self.refresh_button)
+        self.unpair_button = QPushButton("Unpair")
+        self.unpair_button.setFlat(True)
+        self.unpair_button.clicked.connect(self._on_unpair)
+        layout.addWidget(self.unpair_button)
+        return pane
+
+    # ── BROWSE sub-tab ────────────────────────────────────────────────────
+    def _build_browse_tab(self) -> QWidget:
+        w = QWidget()
+        layout = QVBoxLayout(w); layout.setContentsMargins(6, 6, 6, 6); layout.setSpacing(8)
+
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+        self.source_tabs = QTabWidget()
+
+        # Platforms pane: [search] + list
+        plat_pane = QWidget(); plp_l = QVBoxLayout(plat_pane)
+        plp_l.setContentsMargins(4, 4, 4, 4); plp_l.setSpacing(4)
+        self.platform_search = QLineEdit()
+        self.platform_search.setPlaceholderText("Search platforms…")
+        self.platform_search.setClearButtonEnabled(True)
+        self.platform_search.textChanged.connect(self._on_platform_search)
+        plp_l.addWidget(self.platform_search)
+        self.platform_list = QListWidget()
+        self.platform_list.itemSelectionChanged.connect(self._on_platform_selected)
+        self.platform_list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.platform_list.customContextMenuRequested.connect(self._on_platform_context)
+        plp_l.addWidget(self.platform_list, 1)
+        self.source_tabs.addTab(plat_pane, "Platforms")
+
+        # Collections pane: [search] + list
+        coll_pane = QWidget(); clp_l = QVBoxLayout(coll_pane)
+        clp_l.setContentsMargins(4, 4, 4, 4); clp_l.setSpacing(4)
+        self.collection_search = QLineEdit()
+        self.collection_search.setPlaceholderText("Search collections…")
+        self.collection_search.setClearButtonEnabled(True)
+        self.collection_search.textChanged.connect(self._on_collection_search)
+        clp_l.addWidget(self.collection_search)
+        self.collection_list = QListWidget()
+        self.collection_list.itemSelectionChanged.connect(self._on_collection_selected)
+        self.collection_list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.collection_list.customContextMenuRequested.connect(self._on_collection_context)
+        clp_l.addWidget(self.collection_list, 1)
+        self.source_tabs.addTab(coll_pane, "Collections")
+
+        self.source_tabs.currentChanged.connect(self._on_source_tab_changed)
+        splitter.addWidget(self.source_tabs)
+
+        # ROMs pane: [search | loading bar] + table
+        right = QGroupBox("ROMs")
+        rl = QVBoxLayout(right); rl.setContentsMargins(8, 8, 8, 8); rl.setSpacing(4)
+        # header stack: page 0 = search field, page 1 = loading indicator
+        self.rom_header_stack = QStackedWidget()
+        self.rom_search = QLineEdit()
+        self.rom_search.setPlaceholderText("Search ROMs (name, file, platform)…")
+        self.rom_search.setClearButtonEnabled(True)
+        self.rom_search.textChanged.connect(self._on_rom_search)
+        self.rom_header_stack.addWidget(self.rom_search)
+        loading = QWidget()
+        ll = QHBoxLayout(loading); ll.setContentsMargins(0, 0, 0, 0); ll.setSpacing(6)
+        self.rom_loading_label = QLabel("Loading ROMs…")
+        ll.addWidget(self.rom_loading_label)
+        self.rom_progress = QProgressBar()
+        self.rom_progress.setRange(0, 0)   # indeterminate
+        self.rom_progress.setTextVisible(False)
+        ll.addWidget(self.rom_progress, 1)
+        self.rom_cancel_button = QPushButton("Cancel")
+        self.rom_cancel_button.clicked.connect(self._cancel_rom_fetch)
+        ll.addWidget(self.rom_cancel_button)
+        self.rom_header_stack.addWidget(loading)
+        rl.addWidget(self.rom_header_stack)
+        self.rom_table = QTableWidget(0, 4)
+        self.rom_table.setHorizontalHeaderLabels(["Name", "Platform", "File", "Size"])
+        hh = self.rom_table.horizontalHeader()
+        hh.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        hh.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        hh.setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
+        hh.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
+        self.rom_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.rom_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.rom_table.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.rom_table.customContextMenuRequested.connect(self._on_rom_context)
+        rl.addWidget(self.rom_table, 1)
+        splitter.addWidget(right)
+
+        splitter.setStretchFactor(0, 1); splitter.setStretchFactor(1, 3)
+        layout.addWidget(splitter, 1)
+
+        # Filters row (bottom)
+        romm_cfg = self.main_window.config_data.get("romm_config", {})
+        filter_group = QGroupBox("Filters")
+        fg_l = QHBoxLayout(filter_group)
+        fg_l.setContentsMargins(10, 6, 10, 6)
+        self.hide_empty_cb = QCheckBox("Hide empty platforms")
+        self.hide_empty_cb.setChecked(bool(romm_cfg.get("hide_empty", True)))
+        self.hide_empty_cb.stateChanged.connect(self._on_filter_toggle)
+        self.hide_unsupported_cb = QCheckBox("Hide platforms MiSTer can't run")
+        self.hide_unsupported_cb.setChecked(bool(romm_cfg.get("hide_unsupported", True)))
+        self.hide_unsupported_cb.stateChanged.connect(self._on_filter_toggle)
+        fg_l.addWidget(self.hide_empty_cb)
+        fg_l.addWidget(self.hide_unsupported_cb)
+        fg_l.addStretch()
+        layout.addWidget(filter_group)
+        return w
+
+    # ── SYNC sub-tab ──────────────────────────────────────────────────────
+    def _build_sync_tab(self) -> QWidget:
+        w = QWidget()
+        layout = QVBoxLayout(w); layout.setContentsMargins(6, 6, 6, 6); layout.setSpacing(8)
+
+        # Status row: MiSTer connection + last-sync summary
+        status_row = QHBoxLayout()
+        self.mister_status_label = QLabel()
+        status_row.addWidget(self.mister_status_label, 1)
+        self.change_root_button = QPushButton("Change path…")
+        self.change_root_button.setFlat(True)
+        self.change_root_button.clicked.connect(self._edit_mister_root)
+        status_row.addWidget(self.change_root_button)
+        layout.addLayout(status_row)
+        self.last_sync_label = QLabel()
+        self.last_sync_label.setStyleSheet("color: gray;")
+        layout.addWidget(self.last_sync_label)
+
+        # subscribed platforms
+        plat_group = QGroupBox("Subscribed Platforms")
+        pg_l = QVBoxLayout(plat_group)
+        self.sub_platform_list = QListWidget()
+        self.sub_platform_list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.sub_platform_list.customContextMenuRequested.connect(self._on_sub_platform_context)
+        pg_l.addWidget(self.sub_platform_list)
+        hint = QLabel("Right-click a platform in the Browse tab to subscribe. "
+                      "Right-click here to unsubscribe.")
+        hint.setStyleSheet("color: gray;")
+        pg_l.addWidget(hint)
+        layout.addWidget(plat_group)
+
+        # subscribed collections
+        coll_group = QGroupBox("Subscribed Collections")
+        cg_l = QVBoxLayout(coll_group)
+        self.sub_collection_list = QListWidget()
+        self.sub_collection_list.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.sub_collection_list.customContextMenuRequested.connect(self._on_sub_collection_context)
+        cg_l.addWidget(self.sub_collection_list)
+        layout.addWidget(coll_group)
+
+        # Bottom action bar
+        action_bar = QHBoxLayout()
+        romm_cfg = self.main_window.config_data.get("romm_config", {})
+        self.auto_sync_cb = QCheckBox("Auto-sync when MiSTer connects")
+        self.auto_sync_cb.setChecked(bool(romm_cfg.get("auto_sync", False)))
+        self.auto_sync_cb.stateChanged.connect(self._on_options_toggle)
+        action_bar.addWidget(self.auto_sync_cb)
+        self.sync_saves_cb = QCheckBox("Also sync saves && states")
+        self.sync_saves_cb.setChecked(bool(romm_cfg.get("sync_saves", False)))
+        self.sync_saves_cb.stateChanged.connect(self._on_options_toggle)
+        action_bar.addWidget(self.sync_saves_cb)
+        action_bar.addStretch()
+        self.sync_now_button = QPushButton("Sync Now")
+        self.sync_now_button.setDefault(True)
+        self.sync_now_button.clicked.connect(self._on_sync_now)
+        action_bar.addWidget(self.sync_now_button)
+        layout.addLayout(action_bar)
+
+        return w
+
+    def _on_options_toggle(self, _state) -> None:
+        self._save_config(
+            auto_sync=self.auto_sync_cb.isChecked(),
+            sync_saves=self.sync_saves_cb.isChecked(),
+        )
+
+    def _edit_mister_root(self) -> None:
+        current = self._cfg("mister_root", "/media/fat")
+        prompt = (
+            "Path on the MiSTer where games (and saves/states/BIOS) live. "
+            "Default is <code>/media/fat</code> (SD card). Common alternatives: "
+            "<code>/media/usb0</code>, <code>/media/usb1</code>, "
+            "<code>/media/network</code>. Must be absolute, no trailing slash."
+        )
+        text, ok = QInputDialog.getText(
+            self, "MiSTer path", prompt,
+            QLineEdit.EchoMode.Normal, current,
+        )
+        if not ok:
+            return
+        new_val = (text or "").strip().rstrip("/") or "/media/fat"
+        if not new_val.startswith("/"):
+            QMessageBox.warning(self, "Invalid path", "Path must be absolute (start with '/').")
+            return
+        # Optional live validation via SFTP if connected
+        if self._mister_connected():
+            try:
+                sftp = self.main_window.connection.client.open_sftp()
+                try:
+                    sftp.stat(new_val)
+                except (FileNotFoundError, IOError):
+                    resp = QMessageBox.question(
+                        self, "Path not found",
+                        f"<code>{new_val}</code> doesn't exist on the MiSTer. Save anyway?",
+                        QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                        QMessageBox.StandardButton.No,
+                    )
+                    if resp != QMessageBox.StandardButton.Yes:
+                        sftp.close(); return
+                sftp.close()
+            except Exception as exc:
+                self._log(f"MiSTer path validation skipped: {exc}")
+        self._save_config(mister_root=new_val)
+        self._log(f"MiSTer path set to {new_val}")
+        self._update_mister_status()
+
+    # ── last-sync summary ────────────────────────────────────────────────
+    def _render_last_sync(self) -> None:
+        ts = self._cfg("sync_last_run", "")
+        stats = self._cfg("sync_last_stats", {}) or {}
+        if not ts:
+            self.last_sync_label.setText("Last sync: never")
+            return
+        when = _relative_time(ts)
+        parts = [f"{v} {k}" for k, v in stats.items() if v]
+        summary = " — " + ", ".join(parts) if parts else ""
+        self.last_sync_label.setText(f"Last sync: {when}{summary}")
+
+    # ── LOG sub-tab ───────────────────────────────────────────────────────
+    def _build_log_tab(self) -> QWidget:
+        w = QWidget()
+        layout = QVBoxLayout(w); layout.setContentsMargins(6, 6, 6, 6)
+        self.log = QTextEdit(); self.log.setReadOnly(True)
+        layout.addWidget(self.log)
+        return w
+
+    # ── shared helpers ────────────────────────────────────────────────────
+    def _log(self, msg: str) -> None:
+        ts = datetime.now().strftime("%H:%M:%S")
+        self.log.append(f"[{ts}] {msg}")
+
+    def _normalize_code_field(self, text: str) -> None:
+        clean = normalize_pairing_code(text)
+        if clean != text:
+            self.code_edit.blockSignals(True)
+            self.code_edit.setText(clean)
+            self.code_edit.blockSignals(False)
+
+    def _set_busy(self, busy: bool) -> None:
+        self.pair_button.setEnabled(not busy)
+        self.pair_button.setText("Pairing…" if busy else "Pair")
+        if hasattr(self, "refresh_button"):
+            self.refresh_button.setEnabled(not busy)
+        if hasattr(self, "sync_now_button"):
+            self.sync_now_button.setEnabled(not busy and self._mister_connected())
+
+    def _run(self, fn, done):
+        self._set_busy(True)
+        self._worker = RomMWorker(fn)
+        self._worker.progress.connect(self._log)
+
+        def _finished(ok: bool, res):
+            self._set_busy(False)
+            done(ok, res)
+
+        self._worker.finished.connect(_finished)
+        self._worker.start()
+
+    def _save_config(self, **updates) -> None:
+        cfg = self.main_window.config_data.setdefault("romm_config", {})
+        cfg.update(updates)
+        save_config(self.main_window.config_data)
+
+    def _cfg(self, key, default=None):
+        return self.main_window.config_data.get("romm_config", {}).get(key, default)
+
+    def _mister_connected(self) -> bool:
+        conn = getattr(self.main_window, "connection", None)
+        return bool(conn and conn.is_connected())
+
+    def _update_mister_status(self) -> None:
+        conn = getattr(self.main_window, "connection", None)
+        connected = bool(conn and conn.is_connected())
+        root = self._cfg("mister_root", "/media/fat")
+        if connected:
+            self.mister_status_label.setText(
+                f"<b>MiSTer:</b> connected to <code>{conn.host}</code> · "
+                f"path: <code>{root}</code>"
+            )
+            self.sync_now_button.setEnabled(True)
+        else:
+            self.mister_status_label.setText(
+                "<b>MiSTer:</b> <span style='color:#c66'>not connected</span> · "
+                f"path: <code>{root}</code> — connect on the Connection tab to enable sync"
+            )
+            self.sync_now_button.setEnabled(False)
+        self._render_last_sync()
+
+        # Auto-sync: fire on the rising edge (false → true) if enabled + paired.
+        rose = connected and not self._mister_was_connected
+        self._mister_was_connected = connected
+        if (
+            rose
+            and self.auto_sync_cb.isChecked()
+            and self._client is not None
+            and not self._sync_in_progress
+        ):
+            subs = self._cfg("sync_platforms", []) + self._cfg("sync_collections", [])
+            if subs:
+                self._log("Auto-sync: MiSTer connected — starting sync.")
+                self._on_sync_now()
+
+    # ── STARTUP restore ───────────────────────────────────────────────────
+    def _restore_from_config(self) -> None:
+        url, token = self._cfg("url", ""), self._cfg("token", "")
+        if not url or not token:
+            self.paired_pane.hide(); self.unpaired_pane.show()
+            self._update_mister_status()
+            return
+        self._client = RomMClient(url, token=token)
+        self._show_paired(self._cfg("user_display", ""), self._cfg("token_name", ""), url)
+        self._log(f"Restoring RomM session for {url} …")
+        self._on_refresh_lists()
+
+    # ── PAIR / UNPAIR ─────────────────────────────────────────────────────
+    def _on_pair(self) -> None:
+        url = self.url_edit.text().strip()
+        code = normalize_pairing_code(self.code_edit.text())
+        if not url:
+            self._log("URL is required."); return
+        if not code:
+            self._log("Enter the pairing code shown in RomM's UI."); return
+        self._client = RomMClient(url)
+        self._log(f"Exchanging pairing code with {url} …")
+
+        client = self._client
+
+        def task(_progress):
+            payload = client.exchange_pairing_code(code)
+            me = client.whoami()
+            return payload, me
+
+        def done(ok, res):
+            if not ok:
+                exc = res if isinstance(res, Exception) else Exception(str(res))
+                self._log(f"Pairing failed: {exc}")
+                QMessageBox.warning(self, "Pairing failed", str(exc))
+                self._client = None; self.code_edit.clear(); return
+            payload, me = res
+            user_display = me.get("username") or me.get("email") or f"user #{me.get('id', '?')}"
+            self._save_config(
+                url=url,
+                token=payload.get("raw_token", ""),
+                token_id=payload.get("id"),
+                token_name=payload.get("name", ""),
+                user_display=user_display,
+            )
+            self._log(f"Paired as {user_display}.")
+            self.code_edit.clear()
+            self._show_paired(user_display, payload.get("name", ""), url)
+            self._on_refresh_lists()
+
+        self._run(task, done)
+
+    def _show_paired(self, user_display: str, token_name: str, url: str) -> None:
+        # Compact one-liner; token name shown only on hover.
+        self.paired_label.setText(f"🔗 <b>{user_display or '(unknown)'}</b> · {url}")
+        self.paired_label.setToolTip(f"Token: {token_name or '(unnamed)'}")
+        self.unpaired_pane.hide(); self.paired_pane.show()
+        self._update_mister_status()
+
+    def _on_unpair(self) -> None:
+        confirm = QMessageBox.question(
+            self, "Unpair from RomM",
+            "Forget the stored API token on this device?\n\n"
+            "The token stays valid on the RomM server — revoke it in "
+            "Control Panel → API Keys if you want it gone.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if confirm != QMessageBox.StandardButton.Yes:
+            return
+        url = self._cfg("url", "")
+        self._save_config(url=url, token="", token_id=None, token_name="", user_display="")
+        self._client = None
+        self._platforms = []; self._collections = []
+        self.platform_list.clear(); self.collection_list.clear(); self.rom_table.setRowCount(0)
+        self.sub_platform_list.clear(); self.sub_collection_list.clear()
+        self.paired_pane.hide(); self.unpaired_pane.show()
+        self.url_edit.setText(url); self.code_edit.clear()
+        self._log("Unpaired. Token forgotten locally.")
+
+    # ── REFRESH lists ─────────────────────────────────────────────────────
+    def _on_refresh_lists(self) -> None:
+        if self._client is None:
+            return
+        client = self._client
+
+        def task(_progress):
+            return {"platforms": client.get_platforms(), "collections": client.get_collections()}
+
+        def done(ok, res):
+            if not ok:
+                exc = res if isinstance(res, Exception) else Exception(str(res))
+                self._log(f"Fetch failed: {exc}"); return
+            self._platforms = res.get("platforms") or []
+            self._collections = res.get("collections") or []
+            self._log(f"Fetched {len(self._platforms)} platforms, {len(self._collections)} collections.")
+            self._render_platforms()
+            self._render_collections()
+            self._render_subscriptions()
+
+        self._run(task, done)
+
+    @staticmethod
+    def _rom_count(entry: dict) -> int:
+        n = entry.get("rom_count")
+        if n is None:
+            n = entry.get("rom_ids_count", len(entry.get("rom_ids", [])))
+        try:
+            return int(n or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    def _sub_marker(self, is_subbed: bool, is_readonly: bool) -> str:
+        if not is_subbed:
+            return ""
+        return "  ⬇" if is_readonly else "  ★"
+
+    def _render_platforms(self) -> None:
+        self.platform_list.clear()
+        hide_unsup = self.hide_unsupported_cb.isChecked()
+        hide_empty = self.hide_empty_cb.isChecked()
+        subs = set(self._cfg("sync_platforms", []))
+        readonly = set(self._cfg("readonly_platforms", []))
+        shown = 0
+        for p in sorted(self._platforms, key=lambda x: (x.get("name") or x.get("slug") or "").lower()):
+            slug = p.get("slug", "")
+            supported = is_supported(slug)
+            count = self._rom_count(p)
+            if hide_unsup and not supported:
+                continue
+            if hide_empty and count == 0:
+                continue
+            name = p.get("name") or slug or f"#{p.get('id')}"
+            core = core_folder_for_slug(slug) or "—"
+            pid = p.get("id")
+            marker = self._sub_marker(pid in subs, pid in readonly)
+            item = QListWidgetItem(f"{name}  ({count})   [{core}]{marker}")
+            item.setData(Qt.ItemDataRole.UserRole, pid)
+            if not supported:
+                item.setForeground(Qt.GlobalColor.gray)
+            self.platform_list.addItem(item)
+            shown += 1
+        hidden = len(self._platforms) - shown
+        suffix = f" — {hidden} hidden" if hidden else ""
+        self.source_tabs.setTabText(0, f"Platforms ({shown}{suffix})")
+
+    def _render_collections(self) -> None:
+        self.collection_list.clear()
+        hide_empty = self.hide_empty_cb.isChecked()
+        subs = set(self._cfg("sync_collections", []))
+        readonly = set(self._cfg("readonly_collections", []))
+        shown = 0
+        for c in sorted(self._collections, key=lambda x: (x.get("name") or "").lower()):
+            count = self._rom_count(c)
+            if hide_empty and count == 0:
+                continue
+            name = c.get("name") or f"#{c.get('id')}"
+            cid = c.get("id")
+            marker = self._sub_marker(cid in subs, cid in readonly)
+            item = QListWidgetItem(f"{name}  ({count}){marker}")
+            item.setData(Qt.ItemDataRole.UserRole, cid)
+            self.collection_list.addItem(item)
+            shown += 1
+        hidden = len(self._collections) - shown
+        suffix = f" — {hidden} hidden" if hidden else ""
+        self.source_tabs.setTabText(1, f"Collections ({shown}{suffix})")
+
+    def _render_subscriptions(self) -> None:
+        sub_pids = set(self._cfg("sync_platforms", []))
+        sub_cids = set(self._cfg("sync_collections", []))
+        ro_pids = set(self._cfg("readonly_platforms", []))
+        ro_cids = set(self._cfg("readonly_collections", []))
+
+        self.sub_platform_list.clear()
+        for p in self._platforms:
+            if p.get("id") not in sub_pids:
+                continue
+            slug = p.get("slug", "")
+            core = core_folder_for_slug(slug) or "(unsupported!)"
+            mode = "read-only ⬇" if p.get("id") in ro_pids else "sync ★"
+            item = QListWidgetItem(f"{p.get('name')}  ({self._rom_count(p)})   → {core}   [{mode}]")
+            item.setData(Qt.ItemDataRole.UserRole, p.get("id"))
+            if not is_supported(slug):
+                item.setForeground(Qt.GlobalColor.red)
+            self.sub_platform_list.addItem(item)
+
+        self.sub_collection_list.clear()
+        for c in self._collections:
+            if c.get("id") not in sub_cids:
+                continue
+            mode = "read-only ⬇" if c.get("id") in ro_cids else "sync ★"
+            item = QListWidgetItem(f"{c.get('name')}  ({self._rom_count(c)})   [{mode}]")
+            item.setData(Qt.ItemDataRole.UserRole, c.get("id"))
+            self.sub_collection_list.addItem(item)
+
+    def _on_filter_toggle(self, _state) -> None:
+        self._save_config(
+            hide_unsupported=self.hide_unsupported_cb.isChecked(),
+            hide_empty=self.hide_empty_cb.isChecked(),
+        )
+        self._render_platforms()
+        self._render_collections()
+        self._on_platform_search(self.platform_search.text())
+        self._on_collection_search(self.collection_search.text())
+
+    # ── search boxes ──────────────────────────────────────────────────────
+    def _on_platform_search(self, text: str) -> None:
+        needle = (text or "").strip().lower()
+        for i in range(self.platform_list.count()):
+            item = self.platform_list.item(i)
+            item.setHidden(bool(needle) and needle not in item.text().lower())
+
+    def _on_collection_search(self, text: str) -> None:
+        needle = (text or "").strip().lower()
+        for i in range(self.collection_list.count()):
+            item = self.collection_list.item(i)
+            item.setHidden(bool(needle) and needle not in item.text().lower())
+
+    def _on_rom_search(self, _text: str) -> None:
+        self._apply_rom_search()
+
+    def _apply_rom_search(self) -> None:
+        needle = self.rom_search.text().strip().lower()
+        for row in range(self.rom_table.rowCount()):
+            if not needle:
+                self.rom_table.setRowHidden(row, False); continue
+            hit = False
+            for col in (0, 1, 2):
+                it = self.rom_table.item(row, col)
+                if it and needle in it.text().lower():
+                    hit = True; break
+            self.rom_table.setRowHidden(row, not hit)
+
+    # ── BROWSE selection ──────────────────────────────────────────────────
+    def _on_source_tab_changed(self, _index: int) -> None:
+        # clearSelection() alone fires itemSelectionChanged AND leaves the
+        # current item intact — the handler would then re-fetch the same ROMs.
+        # Block signals + reset the current item to truly deselect.
+        for lst in (self.platform_list, self.collection_list):
+            lst.blockSignals(True)
+            lst.setCurrentItem(None)
+            lst.clearSelection()
+            lst.blockSignals(False)
+        self.rom_table.setRowCount(0)
+
+    def _on_platform_selected(self) -> None:
+        item = self.platform_list.currentItem()
+        if not item or self._client is None:
+            return
+        self._load_roms(platform_id=item.data(Qt.ItemDataRole.UserRole), label=f"platform {item.text()}")
+
+    def _on_collection_selected(self) -> None:
+        item = self.collection_list.currentItem()
+        if not item or self._client is None:
+            return
+        self._load_roms(collection_id=item.data(Qt.ItemDataRole.UserRole), label=f"collection {item.text()}")
+
+    def _load_roms(self, *, platform_id=None, collection_id=None, label="") -> None:
+        client = self._client; assert client is not None
+        self._log(f"Fetching ROMs for {label} …")
+        self.rom_table.setRowCount(0)
+        self.rom_search.clear()
+        # Platform column is redundant when viewing a single platform.
+        self.rom_table.setColumnHidden(1, platform_id is not None)
+
+        self.rom_loading_label.setText(f"Loading {label} …")
+        self._begin_rom_load()
+
+        def task(_progress):
+            return client.get_roms(platform_id=platform_id, collection_id=collection_id)
+
+        worker = RomMWorker(task)
+
+        def done(ok, res):
+            # If a newer load started (or user cancelled), drop this result silently.
+            if worker is not self._rom_worker:
+                return
+            self._rom_worker = None
+            self._end_rom_load()
+            if not ok:
+                exc = res if isinstance(res, Exception) else Exception(str(res))
+                self._log(f"ROMs fetch failed: {exc}"); return
+            roms = res or []
+            self._log(f"  → {len(roms)} ROMs")
+            self.rom_table.setRowCount(len(roms))
+            for row, rom in enumerate(roms):
+                slug = (rom.get("platform_fs_slug") or rom.get("platform_slug") or "").lower()
+                plat_display = (
+                    rom.get("platform_display_name")
+                    or rom.get("platform_custom_name")
+                    or rom.get("platform_name")
+                    or slug
+                    or "—"
+                )
+                supported = is_supported(slug)
+                plat_cell = plat_display if supported else f"⚠ {plat_display}"
+                self.rom_table.setItem(row, 0, QTableWidgetItem(str(rom.get("name") or rom.get("fs_name") or "")))
+                self.rom_table.setItem(row, 1, QTableWidgetItem(plat_cell))
+                self.rom_table.setItem(row, 2, QTableWidgetItem(str(rom.get("fs_name") or "")))
+                self.rom_table.setItem(row, 3, QTableWidgetItem(_human_size(rom.get("fs_size_bytes"))))
+                if not supported:
+                    for col in range(4):
+                        it = self.rom_table.item(row, col)
+                        it.setForeground(Qt.GlobalColor.gray)
+                        it.setToolTip(f"No MiSTer core for platform '{slug or 'unknown'}'")
+                # stash the rom dict on col 0 for context-menu actions
+                self.rom_table.item(row, 0).setData(Qt.ItemDataRole.UserRole, rom)
+            self._apply_rom_search()
+
+        worker.finished.connect(done)
+        self._rom_worker = worker
+        worker.start()
+
+    def _begin_rom_load(self) -> None:
+        self.rom_header_stack.setCurrentIndex(1)   # show loading bar
+        # Block selection changes while loading — user must cancel first.
+        self.platform_list.setEnabled(False)
+        self.collection_list.setEnabled(False)
+        self.source_tabs.tabBar().setEnabled(False)
+        self.rom_table.setEnabled(False)
+
+    def _end_rom_load(self) -> None:
+        self.rom_header_stack.setCurrentIndex(0)   # show search field
+        self.platform_list.setEnabled(True)
+        self.collection_list.setEnabled(True)
+        self.source_tabs.tabBar().setEnabled(True)
+        self.rom_table.setEnabled(True)
+
+    def _cancel_rom_fetch(self) -> None:
+        # Orphan the worker — its done() callback will see it's no longer current
+        # and bail. The in-flight HTTP request runs to completion in the background
+        # (harmless: cheap CPU + we ignore its result).
+        if self._rom_worker is None:
+            return
+        self._rom_worker = None
+        self._end_rom_load()
+        self._log("ROM fetch cancelled.")
+
+    # ── CONTEXT MENUS: subscribe / unsubscribe / send ─────────────────────
+    def _on_platform_context(self, pos):
+        item = self.platform_list.itemAt(pos)
+        if not item:
+            return
+        pid = item.data(Qt.ItemDataRole.UserRole)
+        subs = list(self._cfg("sync_platforms", []))
+        slug = next((p.get("slug", "") for p in self._platforms if p.get("id") == pid), "")
+        menu = QMenu(self)
+        if pid in subs:
+            act = menu.addAction("Unsubscribe from sync")
+            act.triggered.connect(lambda: self._toggle_platform_sub(pid, False))
+        else:
+            if not is_supported(slug):
+                menu.addAction("(unsupported — no MiSTer core)").setEnabled(False)
+            else:
+                act = menu.addAction("Subscribe to sync")
+                act.triggered.connect(lambda: self._toggle_platform_sub(pid, True))
+        # BIOS action available whether subscribed or not, as long as core exists.
+        if is_supported(slug):
+            menu.addSeparator()
+            bios_act = menu.addAction("Download BIOS to MiSTer")
+            bios_act.setEnabled(self._mister_connected())
+            bios_act.triggered.connect(lambda: self._download_bios(pid, slug))
+            if not self._mister_connected():
+                menu.addAction("(connect a MiSTer to enable)").setEnabled(False)
+        # Override / add mapping — always available so users can rescue
+        # slugs that are currently unsupported.
+        menu.addSeparator()
+        override_act = menu.addAction("Override MiSTer folder for this platform…")
+        override_act.triggered.connect(lambda: self._edit_core_override(slug))
+        menu.exec(self.platform_list.mapToGlobal(pos))
+
+    def _edit_core_override(self, slug: str) -> None:
+        if not slug:
+            QMessageBox.warning(self, "No slug", "This platform has no slug — can't override.")
+            return
+        overrides = dict(self._cfg("core_overrides", {}) or {})
+        current = overrides.get(slug.lower().strip(), "")
+        default = core_folder_for_slug(slug) or ""
+        prompt = (
+            f"Slug: <b>{slug}</b><br>"
+            f"Current mapping: <code>{current or default or '(unsupported)'}</code>"
+            f"{'  (override)' if current else ''}<br><br>"
+            "Enter the MiSTer folder name under <code>/media/fat/games/</code>. "
+            "Leave blank to <b>clear the override</b>. Type nothing and enter "
+            "an empty string to <b>mark this slug as unsupported</b>."
+        )
+        text, ok = QInputDialog.getText(
+            self, "Override MiSTer folder",
+            prompt,
+            QLineEdit.EchoMode.Normal,
+            current or default,
+        )
+        if not ok:
+            return
+        new_val = text.strip()
+        key = slug.lower().strip()
+        if new_val == default and key in overrides:
+            # user cleared the override back to the built-in default
+            del overrides[key]
+            self._log(f"Cleared override for '{slug}' — reverted to default '{default}'")
+        elif new_val == "" and current == "":
+            # no change
+            return
+        else:
+            overrides[key] = new_val
+            self._log(f"Override set: '{slug}' → '{new_val or '(unsupported)'}'")
+        self._save_config(core_overrides=overrides)
+        apply_core_overrides(overrides)
+        self._render_platforms()
+        self._render_subscriptions()
+
+    def _on_collection_context(self, pos):
+        item = self.collection_list.itemAt(pos)
+        if not item:
+            return
+        cid = item.data(Qt.ItemDataRole.UserRole)
+        subs = list(self._cfg("sync_collections", []))
+        menu = QMenu(self)
+        act = menu.addAction("Unsubscribe from sync" if cid in subs else "Subscribe to sync")
+        act.triggered.connect(lambda: self._toggle_collection_sub(cid, cid not in subs))
+        menu.exec(self.collection_list.mapToGlobal(pos))
+
+    def _on_sub_platform_context(self, pos):
+        item = self.sub_platform_list.itemAt(pos)
+        if not item:
+            return
+        pid = item.data(Qt.ItemDataRole.UserRole)
+        readonly = pid in set(self._cfg("readonly_platforms", []))
+        slug = next((p.get("slug", "") for p in self._platforms if p.get("id") == pid), "")
+        menu = QMenu(self)
+        toggle_label = "Switch to bidirectional sync (★)" if readonly else "Switch to read-only (⬇)"
+        act_ro = menu.addAction(toggle_label)
+        act_ro.triggered.connect(lambda: self._toggle_platform_readonly(pid, not readonly))
+        act = menu.addAction("Unsubscribe")
+        act.triggered.connect(lambda: self._toggle_platform_sub(pid, False))
+        if is_supported(slug):
+            menu.addSeparator()
+            bios_act = menu.addAction("Download BIOS to MiSTer")
+            bios_act.setEnabled(self._mister_connected())
+            bios_act.triggered.connect(lambda: self._download_bios(pid, slug))
+        menu.exec(self.sub_platform_list.mapToGlobal(pos))
+
+    def _download_bios(self, platform_id: int, slug: str) -> None:
+        if self._client is None or not self._mister_connected():
+            return
+        client = self._client
+        conn = self.main_window.connection
+        sftp = conn.client.open_sftp()
+
+        self.main_tabs.setCurrentIndex(2)  # switch to Log so progress is visible
+        self._log(f"Downloading BIOS for platform '{slug}' …")
+
+        mister_root = self._cfg("mister_root", "/media/fat")
+        def task(prog):
+            try:
+                return download_firmware_for_platform(
+                    client, sftp,
+                    platform_id=platform_id, platform_slug=slug,
+                    mister_root=mister_root,
+                    progress=prog,
+                )
+            finally:
+                sftp.close()
+
+        def done(ok, res):
+            if not ok:
+                self._log(f"BIOS download failed: {res}"); return
+            stats = res or {}
+            summary = ", ".join(f"{k}={v}" for k, v in stats.items() if v)
+            self._log(f"BIOS done: {summary or 'nothing to do'}. "
+                      "Rename/relocate per your core's convention (see MiSTer wiki: setup/games/).")
+
+        self._run(task, done)
+
+    def _on_sub_collection_context(self, pos):
+        item = self.sub_collection_list.itemAt(pos)
+        if not item:
+            return
+        cid = item.data(Qt.ItemDataRole.UserRole)
+        readonly = cid in set(self._cfg("readonly_collections", []))
+        menu = QMenu(self)
+        toggle_label = "Switch to bidirectional sync (★)" if readonly else "Switch to read-only (⬇)"
+        act_ro = menu.addAction(toggle_label)
+        act_ro.triggered.connect(lambda: self._toggle_collection_readonly(cid, not readonly))
+        act = menu.addAction("Unsubscribe")
+        act.triggered.connect(lambda: self._toggle_collection_sub(cid, False))
+        menu.exec(self.sub_collection_list.mapToGlobal(pos))
+
+    def _toggle_platform_readonly(self, pid: int, readonly: bool) -> None:
+        subs = list(self._cfg("readonly_platforms", []))
+        if readonly and pid not in subs:
+            subs.append(pid)
+        elif not readonly and pid in subs:
+            subs.remove(pid)
+        self._save_config(readonly_platforms=subs)
+        self._log(f"Platform #{pid} is now {'read-only ⬇' if readonly else 'bidirectional ★'}.")
+        self._render_platforms(); self._render_subscriptions()
+
+    def _toggle_collection_readonly(self, cid: int, readonly: bool) -> None:
+        subs = list(self._cfg("readonly_collections", []))
+        if readonly and cid not in subs:
+            subs.append(cid)
+        elif not readonly and cid in subs:
+            subs.remove(cid)
+        self._save_config(readonly_collections=subs)
+        self._log(f"Collection #{cid} is now {'read-only ⬇' if readonly else 'bidirectional ★'}.")
+        self._render_collections(); self._render_subscriptions()
+
+    def _toggle_platform_sub(self, pid: int, subscribe: bool) -> None:
+        subs = list(self._cfg("sync_platforms", []))
+        if subscribe and pid not in subs:
+            subs.append(pid)
+        elif not subscribe and pid in subs:
+            subs.remove(pid)
+        self._save_config(sync_platforms=subs)
+        self._log(f"{'Subscribed to' if subscribe else 'Unsubscribed from'} platform #{pid}.")
+        self._render_platforms(); self._render_subscriptions()
+
+    def _toggle_collection_sub(self, cid: int, subscribe: bool) -> None:
+        subs = list(self._cfg("sync_collections", []))
+        if subscribe and cid not in subs:
+            subs.append(cid)
+        elif not subscribe and cid in subs:
+            subs.remove(cid)
+        self._save_config(sync_collections=subs)
+        self._log(f"{'Subscribed to' if subscribe else 'Unsubscribed from'} collection #{cid}.")
+        self._render_collections(); self._render_subscriptions()
+
+    # ── ROM row context: Send to MiSTer (manual transfer) ─────────────────
+    def _on_rom_context(self, pos):
+        item = self.rom_table.itemAt(pos)
+        if not item:
+            return
+        row = item.row()
+        rom = self.rom_table.item(row, 0).data(Qt.ItemDataRole.UserRole)
+        if not rom:
+            return
+        slug = (rom.get("platform_fs_slug") or rom.get("platform_slug") or "").lower()
+        supported = is_supported(slug)
+        menu = QMenu(self)
+        act = menu.addAction("Send to MiSTer")
+        act.setEnabled(supported and self._mister_connected())
+        act.triggered.connect(lambda: self._manual_send(rom))
+        if not supported:
+            menu.addAction(f"(unsupported: no MiSTer core for '{slug or 'unknown'}')").setEnabled(False)
+        elif not self._mister_connected():
+            menu.addAction("(not connected to a MiSTer)").setEnabled(False)
+        menu.exec(self.rom_table.mapToGlobal(pos))
+
+    def _manual_send(self, rom: dict) -> None:
+        slug = (rom.get("platform_fs_slug") or rom.get("platform_slug") or "").lower()
+        core = core_folder_for_slug(slug)
+        if core is None:
+            QMessageBox.warning(self, "Unsupported",
+                                f"No MiSTer core for '{slug}' — cannot send this ROM.")
+            return
+        fname = rom.get("fs_name") or ""
+        if not fname:
+            QMessageBox.warning(self, "Missing filename", "This ROM record has no fs_name."); return
+        remote = f"/media/fat/games/{core}/{fname}"
+
+        # confirm overwrite if file exists
+        conn = self.main_window.connection
+        sftp = conn.client.open_sftp()
+        exists = True
+        try:
+            sftp.stat(remote)
+        except (FileNotFoundError, IOError):
+            exists = False
+        if exists:
+            resp = QMessageBox.question(
+                self, "Overwrite?",
+                f"{fname} already exists at {remote} on the MiSTer. Overwrite it?",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
+            )
+            if resp != QMessageBox.StandardButton.Yes:
+                sftp.close(); return
+
+        rom_id = rom.get("id")
+        client = self._client
+        self._log(f"Sending {fname} → {remote} …")
+
+        def task(prog):
+            try:
+                return download_and_push(client, sftp, rom_id, fname, remote,
+                                         progress=lambda w, t: prog(f"  {w}/{t} B"))
+            finally:
+                sftp.close()
+
+        def done(ok, res):
+            if ok:
+                self._log(f"  sent {res} B")
+            else:
+                self._log(f"  FAILED: {res}")
+
+        self._run(task, done)
+
+    # ── SYNC NOW ──────────────────────────────────────────────────────────
+    def _on_sync_now(self) -> None:
+        if self._sync_in_progress:
+            return
+        if self._client is None:
+            return
+        if not self._mister_connected():
+            QMessageBox.warning(self, "Not connected", "Connect to a MiSTer first."); return
+        sub_pids = list(self._cfg("sync_platforms", []))
+        sub_cids = list(self._cfg("sync_collections", []))
+        if not sub_pids and not sub_cids:
+            QMessageBox.information(self, "Nothing subscribed",
+                                    "Right-click platforms or collections in the Browse tab to subscribe."); return
+
+        client = self._client
+        conn = self.main_window.connection
+        sftp = conn.client.open_sftp()
+        ssh_client = conn.client
+        host = conn.host or ""
+        # Per-host manifest of files we've placed on this MiSTer. Deep-copy so
+        # in-place mutation by execute_sync doesn't taint config until we save.
+        full_manifest = dict(self._cfg("sync_manifest", {}) or {})
+        host_manifest = dict(full_manifest.get(host, {}))
+
+        self.main_tabs.setCurrentIndex(2)  # switch to Log so the user sees progress
+        include_assets = self.sync_saves_cb.isChecked()
+        self._log(f"Planning sync (saves&states: {'on' if include_assets else 'off'}) …")
+
+        mister_root = self._cfg("mister_root", "/media/fat")
+        def task(prog):
+            return plan_sync(
+                client,
+                subscribed_platform_ids=sub_pids,
+                subscribed_collection_ids=sub_cids,
+                readonly_platform_ids=self._cfg("readonly_platforms", []),
+                readonly_collection_ids=self._cfg("readonly_collections", []),
+                sftp=sftp,
+                ssh_client=ssh_client,
+                manifest=host_manifest,
+                mister_root=mister_root,
+                include_assets=include_assets,
+                progress=prog,
+            )
+
+        def done(ok, res):
+            if not ok:
+                self._log(f"Plan failed: {res}"); sftp.close(); return
+            plan: SyncPlan = res
+            self._present_plan(plan, sftp, host, host_manifest, full_manifest)
+
+        self._run(task, done)
+
+    def _present_plan(self, plan: SyncPlan, sftp, host: str = "",
+                      host_manifest: dict | None = None,
+                      full_manifest: dict | None = None) -> None:
+        host_manifest = host_manifest if host_manifest is not None else {}
+        full_manifest = full_manifest if full_manifest is not None else {}
+        totals = plan.totals()
+        self._log(
+            f"Plan — ROMs: {totals['download']} download, {totals['overwrite']} conflict, "
+            f"{totals['skip']} unchanged, {totals['orphan']} orphan. "
+            f"Saves: {totals['save_download']}↓/{totals['save_upload']}↑/{totals['save_conflict']}⚔. "
+            f"States: {totals['state_download']}↓/{totals['state_upload']}↑/{totals['state_conflict']}⚔. "
+            f"Unsupported: {totals['unsupported']}. "
+            f"Bytes: {_human_size(totals['bytes_to_download'])}"
+        )
+
+        if plan.unsupported:
+            names = ", ".join(f"{u.name} ({u.slug})" for u in plan.unsupported[:5])
+            more = f" (+{len(plan.unsupported)-5} more)" if len(plan.unsupported) > 5 else ""
+            self._log(f"  Unsupported sources skipped: {names}{more}")
+
+        if plan.filtered_incompatible:
+            self._log(
+                f"  Skipped {plan.filtered_incompatible} save(s)/state(s) tagged for other emulators "
+                "(only mister-tagged assets are compatible with MiSTer cores)."
+            )
+
+        # Ask about ROM overwrite conflicts
+        conflicts = plan.by_kind("overwrite")
+        if conflicts:
+            dlg = OverwriteDecisionDialog(conflicts, self)
+            if dlg.exec() != QDialog.DialogCode.Accepted:
+                self._log("Sync cancelled at ROM conflict prompt."); sftp.close(); return
+            for a in conflicts:
+                a.resolution = dlg.resolution
+
+        # Ask about ROM orphans
+        orphans = plan.by_kind("orphan")
+        if orphans:
+            dlg = OrphanDecisionDialog(orphans, self)
+            if dlg.exec() != QDialog.DialogCode.Accepted:
+                self._log("Sync cancelled at orphan prompt."); sftp.close(); return
+            for a in orphans:
+                a.resolution = dlg.resolution
+
+        # Ask about save/state conflicts (same dialog, different title)
+        save_conflicts = plan.by_kind("save_conflict")
+        if save_conflicts:
+            dlg = OverwriteDecisionDialog(save_conflicts, self,
+                                          title="Save files differ between MiSTer and RomM")
+            if dlg.exec() != QDialog.DialogCode.Accepted:
+                self._log("Sync cancelled at save conflict prompt."); sftp.close(); return
+            for a in save_conflicts:
+                a.resolution = dlg.resolution
+        state_conflicts = plan.by_kind("state_conflict")
+        if state_conflicts:
+            dlg = OverwriteDecisionDialog(state_conflicts, self,
+                                          title="Save states differ between MiSTer and RomM")
+            if dlg.exec() != QDialog.DialogCode.Accepted:
+                self._log("Sync cancelled at state conflict prompt."); sftp.close(); return
+            for a in state_conflicts:
+                a.resolution = dlg.resolution
+
+        # Execute
+        client = self._client
+        conn = self.main_window.connection
+        ssh_client = conn.client
+        self._log("Executing sync …")
+        self._sync_in_progress = True
+
+        mister_root = self._cfg("mister_root", "/media/fat")
+        def task(prog):
+            try:
+                return execute_sync(plan, client, sftp,
+                                    ssh_client=ssh_client,
+                                    manifest=host_manifest,
+                                    mister_root=mister_root, progress=prog)
+            finally:
+                sftp.close()
+
+        def done(ok, res):
+            self._sync_in_progress = False
+            if not ok:
+                self._log(f"Sync failed: {res}"); return
+            stats = res or {}
+            self._log("Sync complete: " + ", ".join(f"{k}={v}" for k, v in stats.items() if v))
+            # Persist the updated per-host manifest back into the global map.
+            if host:
+                full_manifest[host] = host_manifest
+            self._save_config(
+                sync_last_run=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                sync_last_stats=stats,
+                sync_manifest=full_manifest,
+            )
+            self._render_last_sync()
+
+        self._run(task, done)
+
+    # ── hooks expected by main_window ─────────────────────────────────────
+    def update_connection_state(self, lightweight: bool = True) -> None:
+        self._update_mister_status()


### PR DESCRIPTION
**Draft** — opened alongside #92 for code-level review, **not asking to merge yet**.

Please see #92 for the full design, screenshots, and scope discussion. This PR exists so you (and anyone else interested) can review the code in-context, comment inline, and see the diff — rather than passing links to a fork branch around.

## What's in it

- New tab: `ui/tabs/romm_tab.py`
- New core modules: `core/romm.py`, `core/sync.py`, `core/mister_cores.py`
- Minimal edits to existing files: `core/config.py` (+72 lines schema additions), `ui/main_window.py` (+9 lines tab registration)
- **No new dependencies** — reuses `requests` (already in `requirements.txt`).
- Follows the `SaveManagerTab` pattern (PyQt6 + `QThread` workers + `main_window.connection`).

## Prototype status

Runs against a live RomM 5.0.0 server and a real MiSTer at `/media/fat`. Sync path validated end-to-end (subscribe → plan → SFTP push → manifest update). Slug→core folder mapping cross-checked against actual `ls /media/fat/games/` output (case-sensitive; several defaults corrected).

## Flexibility on shape

Happy to:
- **Split into smaller PRs** for easier review (Phase A = browse + ROM sync + BIOS, Phase B = save/state sync, Phase C = read-only + overrides + configurable path).
- **Rebase onto v6.4.0** (branched from v6.3.1 `b1c847e`; no overlap with the DreamSTer additions).
- **Adjust code style** to match your preferences.
- **Add tests** if you'd like to establish a test suite as part of this.

Discuss on #92; will convert this PR to Ready-for-review once we've aligned on scope.