### PR TITLE
Fix NameError when disabling Zaparoo Frontend

### DIFF
--- a/mister-companion/ui/install_center_actions.py
+++ b/mister-companion/ui/install_center_actions.py
@@ -29,6 +29,7 @@ from core.extras_mister_quake import upload_mister_quake_paks, upload_mister_qua
 from core.extras_mister_duke3d import upload_mister_duke3d_grp, upload_mister_duke3d_grp_local
 from core.extras_dreamster import upload_dreamster_bios, upload_dreamster_bios_local
 from core.extras_paprium_megadrive import open_paprium_game_folder_local, open_paprium_game_folder_on_host
+from core.extras_zaparoo_launcher import disable_zaparoo_launcher_frontend, disable_zaparoo_launcher_frontend_local
 from ui.dialogs.cifs_config_dialog import CifsConfigDialog
 from ui.dialogs.dav_browser_config_dialog import DavBrowserConfigDialog
 from ui.dialogs.ftp_save_sync_config_dialog import FtpSaveSyncConfigDialog


### PR DESCRIPTION
## Summary
- `disable_zaparoo_frontend` in `ui/install_center_actions.py` called `disable_zaparoo_launcher_frontend` / `disable_zaparoo_launcher_frontend_local` without importing them from `core.extras_zaparoo_launcher`, causing `NameError: name 'disable_zaparoo_launcher_frontend' is not defined` when clicking "Disable" on the Zaparoo Frontend in the Install Centre.
- Adds the missing import. Both functions already existed with matching signatures, so no other changes were needed.

Fixes #95

## Test plan
- [x] App launches cleanly with the fix (no import errors)
- [x] Reproduced the original bug on a real MiSTer, applied the fix, confirmed "Disable" on Zaparoo Frontend now works and no longer errors